### PR TITLE
支持以空格分割的订阅节点和空订阅节点的处理 (#2770)

### DIFF
--- a/package/lean/luci-app-ssr-plus/root/usr/share/shadowsocksr/subscribe.lua
+++ b/package/lean/luci-app-ssr-plus/root/usr/share/shadowsocksr/subscribe.lua
@@ -112,6 +112,11 @@ local function processData(szType, content)
         hash = md5(luci.jsonc.stringify(content))
     end
     result.hashkey = hash
+    -- 如果节点内容为空，返回无效的节点信息
+    if content == '' then
+        result.server = ''
+        return result, hash
+    end
     if szType == 'ssr' then
         local dat = split(content, "/\\?")
         local hostInfo = split(dat[1], ':')
@@ -232,7 +237,7 @@ local execute = function()
                     node = servers
                 else
                     -- ssd 外的格式
-                    node = split(base64Decode(raw, true), "\n")
+                    node = split(base64Decode(raw, true):gsub(" ", "\n"), "\n")
                 end
                 for _, v in ipairs(node) do
                     if v then


### PR DESCRIPTION
* 支持以空格分割的订阅节点

* 修复订阅内容为空字符串时导致的json格式转换异常