### PR TITLE
kernel: backport out-of-memory fix for non-Ethernet devices (zerotier…

### DIFF
--- a/target/linux/generic/backport-4.14/600-ipv6-addrconf-call-ipv6_mc_up-for-non-Ethernet-inter.patch
+++ b/target/linux/generic/backport-4.14/600-ipv6-addrconf-call-ipv6_mc_up-for-non-Ethernet-inter.patch
@@ -1,0 +1,71 @@
+From 82afdcd4ec3c8ca6551cbf7c43c09e2fd240487a Mon Sep 17 00:00:00 2001
+From: Hangbin Liu <liuhangbin@gmail.com>
+Date: Tue, 10 Mar 2020 15:27:37 +0800
+Subject: [PATCH] ipv6/addrconf: call ipv6_mc_up() for non-Ethernet interface
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Rafał found an issue that for non-Ethernet interface, if we down and up
+frequently, the memory will be consumed slowly.
+
+The reason is we add allnodes/allrouters addressed in multicast list in
+ipv6_add_dev(). When link down, we call ipv6_mc_down(), store all multicast
+addresses via mld_add_delrec(). But when link up, we don't call ipv6_mc_up()
+for non-Ethernet interface to remove the addresses. This makes idev->mc_tomb
+getting bigger and bigger. The call stack looks like:
+
+addrconf_notify(NETDEV_REGISTER)
+	ipv6_add_dev
+		ipv6_dev_mc_inc(ff01::1)
+		ipv6_dev_mc_inc(ff02::1)
+		ipv6_dev_mc_inc(ff02::2)
+
+addrconf_notify(NETDEV_UP)
+	addrconf_dev_config
+		/* Alas, we support only Ethernet autoconfiguration. */
+		return;
+
+addrconf_notify(NETDEV_DOWN)
+	addrconf_ifdown
+		ipv6_mc_down
+			igmp6_group_dropped(ff02::2)
+				mld_add_delrec(ff02::2)
+			igmp6_group_dropped(ff02::1)
+			igmp6_group_dropped(ff01::1)
+
+After investigating, I can't found a rule to disable multicast on
+non-Ethernet interface. In RFC2460, the link could be Ethernet, PPP, ATM,
+tunnels, etc. In IPv4, it doesn't check the dev type when calls ip_mc_up()
+in inetdev_event(). Even for IPv6, we don't check the dev type and call
+ipv6_add_dev(), ipv6_dev_mc_inc() after register device.
+
+So I think it's OK to fix this memory consumer by calling ipv6_mc_up() for
+non-Ethernet interface.
+
+v2: Also check IFF_MULTICAST flag to make sure the interface supports
+    multicast
+
+Reported-by: Rafał Miłecki <zajec5@gmail.com>
+Tested-by: Rafał Miłecki <zajec5@gmail.com>
+Fixes: 74235a25c673 ("[IPV6] addrconf: Fix IPv6 on tuntap tunnels")
+Fixes: 1666d49e1d41 ("mld: do not remove mld souce list info when set link down")
+Signed-off-by: Hangbin Liu <liuhangbin@gmail.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ net/ipv6/addrconf.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+--- a/net/ipv6/addrconf.c
++++ b/net/ipv6/addrconf.c
+@@ -3223,6 +3223,10 @@ static void addrconf_dev_config(struct n
+ 	    (dev->type != ARPHRD_TUNNEL) &&
+ 	    (dev->type != ARPHRD_NONE)) {
+ 		/* Alas, we support only Ethernet autoconfiguration. */
++		idev = __in6_dev_get(dev);
++		if (!IS_ERR_OR_NULL(idev) && dev->flags & IFF_UP &&
++		    dev->flags & IFF_MULTICAST)
++			ipv6_mc_up(idev);
+ 		return;
+ 	}
+ 

--- a/target/linux/generic/backport-4.19/600-ipv6-addrconf-call-ipv6_mc_up-for-non-Ethernet-inter.patch
+++ b/target/linux/generic/backport-4.19/600-ipv6-addrconf-call-ipv6_mc_up-for-non-Ethernet-inter.patch
@@ -1,0 +1,71 @@
+From 82afdcd4ec3c8ca6551cbf7c43c09e2fd240487a Mon Sep 17 00:00:00 2001
+From: Hangbin Liu <liuhangbin@gmail.com>
+Date: Tue, 10 Mar 2020 15:27:37 +0800
+Subject: [PATCH] ipv6/addrconf: call ipv6_mc_up() for non-Ethernet interface
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Rafał found an issue that for non-Ethernet interface, if we down and up
+frequently, the memory will be consumed slowly.
+
+The reason is we add allnodes/allrouters addressed in multicast list in
+ipv6_add_dev(). When link down, we call ipv6_mc_down(), store all multicast
+addresses via mld_add_delrec(). But when link up, we don't call ipv6_mc_up()
+for non-Ethernet interface to remove the addresses. This makes idev->mc_tomb
+getting bigger and bigger. The call stack looks like:
+
+addrconf_notify(NETDEV_REGISTER)
+	ipv6_add_dev
+		ipv6_dev_mc_inc(ff01::1)
+		ipv6_dev_mc_inc(ff02::1)
+		ipv6_dev_mc_inc(ff02::2)
+
+addrconf_notify(NETDEV_UP)
+	addrconf_dev_config
+		/* Alas, we support only Ethernet autoconfiguration. */
+		return;
+
+addrconf_notify(NETDEV_DOWN)
+	addrconf_ifdown
+		ipv6_mc_down
+			igmp6_group_dropped(ff02::2)
+				mld_add_delrec(ff02::2)
+			igmp6_group_dropped(ff02::1)
+			igmp6_group_dropped(ff01::1)
+
+After investigating, I can't found a rule to disable multicast on
+non-Ethernet interface. In RFC2460, the link could be Ethernet, PPP, ATM,
+tunnels, etc. In IPv4, it doesn't check the dev type when calls ip_mc_up()
+in inetdev_event(). Even for IPv6, we don't check the dev type and call
+ipv6_add_dev(), ipv6_dev_mc_inc() after register device.
+
+So I think it's OK to fix this memory consumer by calling ipv6_mc_up() for
+non-Ethernet interface.
+
+v2: Also check IFF_MULTICAST flag to make sure the interface supports
+    multicast
+
+Reported-by: Rafał Miłecki <zajec5@gmail.com>
+Tested-by: Rafał Miłecki <zajec5@gmail.com>
+Fixes: 74235a25c673 ("[IPV6] addrconf: Fix IPv6 on tuntap tunnels")
+Fixes: 1666d49e1d41 ("mld: do not remove mld souce list info when set link down")
+Signed-off-by: Hangbin Liu <liuhangbin@gmail.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ net/ipv6/addrconf.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+--- a/net/ipv6/addrconf.c
++++ b/net/ipv6/addrconf.c
+@@ -3291,6 +3291,10 @@ static void addrconf_dev_config(struct n
+ 	    (dev->type != ARPHRD_NONE) &&
+ 	    (dev->type != ARPHRD_RAWIP)) {
+ 		/* Alas, we support only Ethernet autoconfiguration. */
++		idev = __in6_dev_get(dev);
++		if (!IS_ERR_OR_NULL(idev) && dev->flags & IFF_UP &&
++		    dev->flags & IFF_MULTICAST)
++			ipv6_mc_up(idev);
+ 		return;
+ 	}
+ 


### PR DESCRIPTION
…, mwan3 etc...)


