### PR TITLE
mbedtls: update to 2.16.7

### DIFF
--- a/package/libs/mbedtls/Makefile
+++ b/package/libs/mbedtls/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mbedtls
-PKG_VERSION:=2.16.6
+PKG_VERSION:=2.16.7
 PKG_RELEASE:=1
 PKG_USE_MIPS16:=0
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-gpl.tgz
-PKG_SOURCE_URL:=https://tls.mbed.org/download/
-PKG_HASH:=80a484df42f32dbe95665cd4b18ce0dd14b6c67dfd561d36d1475802e41eb3ed
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/ARMmbed/mbedtls/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=c95b11557ee97d2bdfd48cd57cf9b648a6cddd2ca879e3c35c4e7525f2871992
 
 PKG_BUILD_PARALLEL:=1
 PKG_LICENSE:=GPL-2.0-or-later

--- a/package/libs/mbedtls/patches/200-config.patch
+++ b/package/libs/mbedtls/patches/200-config.patch
@@ -1,6 +1,6 @@
 --- a/include/mbedtls/config.h
 +++ b/include/mbedtls/config.h
-@@ -633,14 +633,14 @@
+@@ -658,14 +658,14 @@
   *
   * Enable Output Feedback mode (OFB) for symmetric ciphers.
   */
@@ -17,7 +17,7 @@
  
  /**
   * \def MBEDTLS_CIPHER_NULL_CIPHER
-@@ -757,19 +757,19 @@
+@@ -782,19 +782,19 @@
   *
   * Comment macros to disable the curve and functions for it
   */
@@ -46,7 +46,7 @@
  
  /**
   * \def MBEDTLS_ECP_NIST_OPTIM
-@@ -871,7 +871,7 @@
+@@ -918,7 +918,7 @@
   *             See dhm.h for more details.
   *
   */
@@ -55,7 +55,7 @@
  
  /**
   * \def MBEDTLS_KEY_EXCHANGE_ECDHE_PSK_ENABLED
-@@ -891,7 +891,7 @@
+@@ -938,7 +938,7 @@
   *      MBEDTLS_TLS_ECDHE_PSK_WITH_3DES_EDE_CBC_SHA
   *      MBEDTLS_TLS_ECDHE_PSK_WITH_RC4_128_SHA
   */
@@ -64,7 +64,7 @@
  
  /**
   * \def MBEDTLS_KEY_EXCHANGE_RSA_PSK_ENABLED
-@@ -916,7 +916,7 @@
+@@ -963,7 +963,7 @@
   *      MBEDTLS_TLS_RSA_PSK_WITH_3DES_EDE_CBC_SHA
   *      MBEDTLS_TLS_RSA_PSK_WITH_RC4_128_SHA
   */
@@ -73,7 +73,7 @@
  
  /**
   * \def MBEDTLS_KEY_EXCHANGE_RSA_ENABLED
-@@ -1050,7 +1050,7 @@
+@@ -1097,7 +1097,7 @@
   *      MBEDTLS_TLS_ECDH_ECDSA_WITH_CAMELLIA_128_GCM_SHA256
   *      MBEDTLS_TLS_ECDH_ECDSA_WITH_CAMELLIA_256_GCM_SHA384
   */
@@ -82,7 +82,7 @@
  
  /**
   * \def MBEDTLS_KEY_EXCHANGE_ECDH_RSA_ENABLED
-@@ -1074,7 +1074,7 @@
+@@ -1121,7 +1121,7 @@
   *      MBEDTLS_TLS_ECDH_RSA_WITH_CAMELLIA_128_GCM_SHA256
   *      MBEDTLS_TLS_ECDH_RSA_WITH_CAMELLIA_256_GCM_SHA384
   */
@@ -91,7 +91,7 @@
  
  /**
   * \def MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED
-@@ -1178,7 +1178,7 @@
+@@ -1225,7 +1225,7 @@
   * This option is only useful if both MBEDTLS_SHA256_C and
   * MBEDTLS_SHA512_C are defined. Otherwise the available hash module is used.
   */
@@ -100,7 +100,7 @@
  
  /**
   * \def MBEDTLS_ENTROPY_NV_SEED
-@@ -1273,14 +1273,14 @@
+@@ -1320,14 +1320,14 @@
   * Uncomment this macro to disable the use of CRT in RSA.
   *
   */
@@ -117,7 +117,7 @@
  
  /**
   * \def MBEDTLS_SHA256_SMALLER
-@@ -1434,7 +1434,7 @@
+@@ -1481,7 +1481,7 @@
   *          configuration of this extension).
   *
   */
@@ -126,7 +126,7 @@
  
  /**
   * \def MBEDTLS_SSL_SRV_SUPPORT_SSLV2_CLIENT_HELLO
-@@ -1609,7 +1609,7 @@
+@@ -1656,7 +1656,7 @@
   *
   * Comment this macro to disable support for SSL session tickets
   */
@@ -135,7 +135,7 @@
  
  /**
   * \def MBEDTLS_SSL_EXPORT_KEYS
-@@ -1639,7 +1639,7 @@
+@@ -1686,7 +1686,7 @@
   *
   * Comment this macro to disable support for truncated HMAC in SSL
   */
@@ -144,7 +144,7 @@
  
  /**
   * \def MBEDTLS_SSL_TRUNCATED_HMAC_COMPAT
-@@ -1698,7 +1698,7 @@
+@@ -1745,7 +1745,7 @@
   *
   * Comment this to disable run-time checking and save ROM space
   */
@@ -153,7 +153,7 @@
  
  /**
   * \def MBEDTLS_X509_ALLOW_EXTENSIONS_NON_V3
-@@ -2028,7 +2028,7 @@
+@@ -2075,7 +2075,7 @@
   *      MBEDTLS_TLS_PSK_WITH_CAMELLIA_128_GCM_SHA256
   *      MBEDTLS_TLS_PSK_WITH_CAMELLIA_128_CBC_SHA256
   */
@@ -162,7 +162,7 @@
  
  /**
   * \def MBEDTLS_ARIA_C
-@@ -2094,7 +2094,7 @@
+@@ -2141,7 +2141,7 @@
   * This module enables the AES-CCM ciphersuites, if other requisites are
   * enabled as well.
   */
@@ -171,7 +171,7 @@
  
  /**
   * \def MBEDTLS_CERTS_C
-@@ -2106,7 +2106,7 @@
+@@ -2153,7 +2153,7 @@
   *
   * This module is used for testing (ssl_client/server).
   */
@@ -180,7 +180,7 @@
  
  /**
   * \def MBEDTLS_CHACHA20_C
-@@ -2214,7 +2214,7 @@
+@@ -2261,7 +2261,7 @@
   * \warning   DES is considered a weak cipher and its use constitutes a
   *            security risk. We recommend considering stronger ciphers instead.
   */
@@ -189,7 +189,7 @@
  
  /**
   * \def MBEDTLS_DHM_C
-@@ -2377,7 +2377,7 @@
+@@ -2424,7 +2424,7 @@
   * This module adds support for the Hashed Message Authentication Code
   * (HMAC)-based key derivation function (HKDF).
   */
@@ -198,7 +198,7 @@
  
  /**
   * \def MBEDTLS_HMAC_DRBG_C
-@@ -2687,7 +2687,7 @@
+@@ -2734,7 +2734,7 @@
   *
   * This module enables abstraction of common (libc) functions.
   */
@@ -207,7 +207,7 @@
  
  /**
   * \def MBEDTLS_POLY1305_C
-@@ -2708,7 +2708,7 @@
+@@ -2755,7 +2755,7 @@
   * Caller:  library/md.c
   *
   */
@@ -216,7 +216,7 @@
  
  /**
   * \def MBEDTLS_RSA_C
-@@ -2815,7 +2815,7 @@
+@@ -2862,7 +2862,7 @@
   *
   * Requires: MBEDTLS_CIPHER_C
   */
@@ -225,7 +225,7 @@
  
  /**
   * \def MBEDTLS_SSL_CLI_C
-@@ -2915,7 +2915,7 @@
+@@ -2962,7 +2962,7 @@
   *
   * This module provides run-time version information.
   */
@@ -234,7 +234,7 @@
  
  /**
   * \def MBEDTLS_X509_USE_C
-@@ -3025,7 +3025,7 @@
+@@ -3072,7 +3072,7 @@
   * Module:  library/xtea.c
   * Caller:
   */


### PR DESCRIPTION
Mbed TLS 2.16.7 is a maintenance release of the Mbed TLS 2.16 branch,
and provides bug fixes and minor enhancements. This release includes
fixes for security issues and the most severe one is described in more
detail in a security advisory:
https://tls.mbed.org/tech-updates/security-advisories/mbedtls-security-advisory-2020-07

* Fix a side channel vulnerability in modular exponentiation that could
reveal an RSA private key used in a secure enclave.
* Fix side channel in mbedtls_ecp_check_pub_priv() and
mbedtls_pk_parse_key() / mbedtls_pk_parse_keyfile() (when loading a private
key that didn't include the uncompressed public key), as well as
mbedtls_ecp_mul() / mbedtls_ecp_mul_restartable() when called with a NULL
f_rng argument. An attacker with access to precise enough timing and
memory access information (typically an untrusted operating system
attacking a secure enclave) could fully recover the ECC private key.
* Fix issue in Lucky 13 counter-measure that could make it ineffective when
hardware accelerators were used (using one of the MBEDTLS_SHAxxx_ALT
macros).

Due to Mbed TLS moving from ARMmbed to the Trusted Firmware project, some
changes to the download URLs are required. For the time being, the
ARMmbed/mbedtls Github repository is the canonical source for Mbed TLS.

Signed-off-by: Magnus Kroken <mkroken@gmail.com>
[Use https://codeload.github.com and new tar.gz file]
Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [ ] 我知道
