### PR TITLE
openssl: bump to 1.1.1h

### DIFF
--- a/package/libs/openssl/Makefile
+++ b/package/libs/openssl/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssl
 PKG_BASE:=1.1.1
-PKG_BUGFIX:=g
+PKG_BUGFIX:=h
 PKG_VERSION:=$(PKG_BASE)$(PKG_BUGFIX)
 PKG_RELEASE:=1
 PKG_USE_MIPS16:=0
@@ -25,7 +25,7 @@ PKG_SOURCE_URL:= \
 	ftp://ftp.pca.dfn.de/pub/tools/net/openssl/source/ \
 	https://www.openssl.org/source/ \
 	https://www.openssl.org/source/old/$(PKG_BASE)/
-PKG_HASH:=ddb04774f1e32f0c49751e21b67216ac87852ceb056b75209af2443400636d46
+PKG_HASH:=5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9
 
 PKG_LICENSE:=OpenSSL
 PKG_LICENSE_FILES:=LICENSE

--- a/package/libs/openssl/patches/100-Configure-afalg-support.patch
+++ b/package/libs/openssl/patches/100-Configure-afalg-support.patch
@@ -12,7 +12,7 @@ diff --git a/Configure b/Configure
 index 5a699836f3..74d057c219 100755
 --- a/Configure
 +++ b/Configure
-@@ -1532,7 +1532,9 @@ unless ($disabled{"crypto-mdebug-backtrace"})
+@@ -1545,7 +1545,9 @@ unless ($disabled{"crypto-mdebug-backtrace"})
  
  unless ($disabled{afalgeng}) {
      $config{afalgeng}="";

--- a/package/libs/openssl/patches/130-dont-build-tests-fuzz.patch
+++ b/package/libs/openssl/patches/130-dont-build-tests-fuzz.patch
@@ -11,7 +11,7 @@ diff --git a/Configure b/Configure
 index 74d057c219..5813e9f8fe 100755
 --- a/Configure
 +++ b/Configure
-@@ -296,7 +296,7 @@ my $auto_threads=1;    # enable threads automatically? true by default
+@@ -318,7 +318,7 @@ my $auto_threads=1;    # enable threads automatically? true by default
  my $default_ranlib;
  
  # Top level directories to build
@@ -20,7 +20,7 @@ index 74d057c219..5813e9f8fe 100755
  # crypto/ subdirectories to build
  $config{sdirs} = [
      "objects",
-@@ -308,7 +308,7 @@ $config{sdirs} = [
+@@ -330,7 +330,7 @@ $config{sdirs} = [
      "cms", "ts", "srp", "cmac", "ct", "async", "kdf", "store"
      ];
  # test/ subdirectories to build


### PR DESCRIPTION
This is a bug-fix release.  Patches were refreshed.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [ ] 我知道
