### PR TITLE
mtwifi: mt7615: fix multi-profile merge

### DIFF
--- a/package/lean/mt/drivers/mt_wifi/files/dbdc.l1profile.dat
+++ b/package/lean/mt/drivers/mt_wifi/files/dbdc.l1profile.dat
@@ -1,12 +1,12 @@
 Default
 INDEX0=MT7615
-INDEX0_profile_path=/etc/wireless/mt7615/mt7615.1.2G.dat;/etc/wireless/mt7615/mt7615.1.5G.dat
+INDEX0_profile_path=/etc/wireless/mt7615/mt7615.1.5G.dat;/etc/wireless/mt7615/mt7615.1.2G.dat
 INDEX0_EEPROM_offset=0x0
 INDEX0_EEPROM_size=0x4000
 INDEX0_EEPROM_name=e2p
-INDEX0_main_ifname=rax0;ra0
-INDEX0_ext_ifname=rax;ra
-INDEX0_wds_ifname=wdsx;wds
-INDEX0_apcli_ifname=apclix;apcli
+INDEX0_main_ifname=ra0;rax0
+INDEX0_ext_ifname=ra;rax
+INDEX0_wds_ifname=wds;wdsx
+INDEX0_apcli_ifname=apcli;apclix
 INDEX0_single_sku_path=/etc_ro/Wireless/SingleSKU_mt7615e-sku.dat
 INDEX0_bf_sku_path=/etc_ro/Wireless/SingleSKU_mt7615e-sku-bf.dat


### PR DESCRIPTION
Currently some settings like AutoChannelSelect, CountryRegion(ABand),
HT_BW/VHT_BW are not respected. This is due to wrong multi-profile
merging when l1profile.dat is not consistent with compiling flag
DEFAULT_5G_PROFILE.

5g profile should be put before 2g profile when DEFAULT_5G_PROFILE is
set.

References:
- https://github.com/coolsnowwolf/lede/blob/099439f051a8b2393554eb26cec2df074f653fae/package/lean/mt/drivers/mt7615d/Makefile#L52
- https://github.com/coolsnowwolf/lede/blob/099439f051a8b2393554eb26cec2df074f653fae/package/lean/mt/drivers/mt7615d/src/mt_wifi/os/linux/rt_profile.c#L211

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [ ] 我知道
