### PR TITLE
openssl: update to 1.1.1i

### DIFF
--- a/package/libs/openssl/Makefile
+++ b/package/libs/openssl/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssl
 PKG_BASE:=1.1.1
-PKG_BUGFIX:=h
+PKG_BUGFIX:=i
 PKG_VERSION:=$(PKG_BASE)$(PKG_BUGFIX)
 PKG_RELEASE:=1
 PKG_USE_MIPS16:=0
@@ -25,7 +25,7 @@ PKG_SOURCE_URL:= \
 	ftp://ftp.pca.dfn.de/pub/tools/net/openssl/source/ \
 	https://www.openssl.org/source/ \
 	https://www.openssl.org/source/old/$(PKG_BASE)/
-PKG_HASH:=5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9
+PKG_HASH:=e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242
 
 PKG_LICENSE:=OpenSSL
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
Fixes: CVE-2020-1971, defined as high severity, summarized as:
NULL pointer deref in GENERAL_NAME_cmp function can lead to a DOS
attack.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [ ] 我知道
