### PR TITLE
ipq40xx: improve cpu operating points and overclosk to 896Mz (#6049)

### DIFF
--- a/target/linux/ipq40xx/patches-4.19/999-ipq40xx-unlock-cpu-frequency.patch
+++ b/target/linux/ipq40xx/patches-4.19/999-ipq40xx-unlock-cpu-frequency.patch
@@ -1,0 +1,57 @@
+From: William <gw826943555@qq.com>
+Subject: [PATCH] ipq40xx: improve CPU clock
+Date: Tue, 15 Dec 2020 15:28:10 +0800
+
+This patch will match the clock-latency-ns values in the device tree 
+for those found inside the OEM device tree and kernel source code and 
+unlock 896Mhz CPU operating points.
+
+Signed-off-by: William <gw826943555@qq.com>
+---
+--- a/arch/arm/boot/dts/qcom-ipq4019.dtsi
++++ b/arch/arm/boot/dts/qcom-ipq4019.dtsi
+@@ -121,23 +121,28 @@
+ 		opp-48000000 {
+ 			opp-hz = /bits/ 64 <48000000>;
+ 			opp-microvolt = <1100000>;
+-			clock-latency-ns = <256000>;
++			clock-latency-ns = <100000>;
+ 		};
+ 		opp-200000000 {
+ 			opp-hz = /bits/ 64 <200000000>;
+ 			opp-microvolt = <1100000>;
+-			clock-latency-ns = <256000>;
++			clock-latency-ns = <100000>;
+ 		};
+ 		opp-500000000 {
+ 			opp-hz = /bits/ 64 <500000000>;
+ 			opp-microvolt = <1100000>;
+-			clock-latency-ns = <256000>;
++			clock-latency-ns = <100000>;
+ 		};
+ 		opp-716000000 {
+ 			opp-hz = /bits/ 64 <716000000>;
+ 			opp-microvolt = <1100000>;
+-			clock-latency-ns = <256000>;
++			clock-latency-ns = <100000>;
+  		};
++		opp-896000000 {
++			opp-hz = /bits/ 64 <896000000>;
++			opp-microvolt = <1100000>;
++			clock-latency-ns = <100000>;
++		};
+ 	};
+ 
+ 	pmu {
+--- a/drivers/clk/qcom/gcc-ipq4019.c
++++ b/drivers/clk/qcom/gcc-ipq4019.c
+@@ -587,6 +587,9 @@ static const struct freq_tbl ftbl_gcc_ap
+ 	F(632000000, P_DDRPLLAPSS, 1, 0, 0),
+ 	F(672000000, P_DDRPLLAPSS, 1, 0, 0),
+ 	F(716000000, P_DDRPLLAPSS, 1, 0, 0),
++	F(768000000, P_DDRPLLAPSS, 1, 0, 0),
++	F(823000000, P_DDRPLLAPSS, 1, 0, 0),
++	F(896000000, P_DDRPLLAPSS, 1, 0, 0),
+ 	{ }
+ };
+ 

--- a/target/linux/ipq40xx/patches-5.4/999-ipq40xx-unlock-cpu-frequency.patch
+++ b/target/linux/ipq40xx/patches-5.4/999-ipq40xx-unlock-cpu-frequency.patch
@@ -1,0 +1,53 @@
+From: William <gw826943555@qq.com>
+Subject: [PATCH] ipq40xx: improve CPU clock
+Date: Tue, 15 Dec 2020 15:26:35 +0800
+
+This patch will match the clock-latency-ns values in the device tree 
+for those found inside the OEM device tree and kernel source code and 
+unlock 896Mhz CPU operating points.
+
+Signed-off-by: William <gw826943555@qq.com>
+---
+--- a/arch/arm/boot/dts/qcom-ipq4019.dtsi
++++ b/arch/arm/boot/dts/qcom-ipq4019.dtsi
+@@ -114,20 +114,24 @@
+ 
+ 		opp-48000000 {
+ 			opp-hz = /bits/ 64 <48000000>;
+-			clock-latency-ns = <256000>;
++			clock-latency-ns = <100000>;
+ 		};
+ 		opp-200000000 {
+ 			opp-hz = /bits/ 64 <200000000>;
+-			clock-latency-ns = <256000>;
++			clock-latency-ns = <100000>;
+ 		};
+ 		opp-500000000 {
+ 			opp-hz = /bits/ 64 <500000000>;
+-			clock-latency-ns = <256000>;
++			clock-latency-ns = <100000>;
+ 		};
+ 		opp-716000000 {
+ 			opp-hz = /bits/ 64 <716000000>;
+-			clock-latency-ns = <256000>;
++			clock-latency-ns = <100000>;
+  		};
++		opp-896000000 {
++			opp-hz = /bits/ 64 <896000000>;
++			clock-latency-ns = <100000>;
++		};
+ 	};
+ 
+ 	memory {
+--- a/drivers/clk/qcom/gcc-ipq4019.c
++++ b/drivers/clk/qcom/gcc-ipq4019.c
+@@ -579,6 +579,9 @@ static const struct freq_tbl ftbl_gcc_ap
+ 	F(632000000, P_DDRPLLAPSS, 1, 0, 0),
+ 	F(672000000, P_DDRPLLAPSS, 1, 0, 0),
+ 	F(716000000, P_DDRPLLAPSS, 1, 0, 0),
++	F(768000000, P_DDRPLLAPSS, 1, 0, 0),
++	F(823000000, P_DDRPLLAPSS, 1, 0, 0),
++	F(896000000, P_DDRPLLAPSS, 1, 0, 0),
+ 	{ }
+ };
+ 


### PR DESCRIPTION
this patch improve cpu operating points to 896Mhz and match the clock-latency-ns values in the device tree  for those found inside the OEM device tree and kernel source code

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [ ] 我知道
