### PR TITLE
openssl: bump to 1.1.1j

### DIFF
--- a/package/libs/openssl/Makefile
+++ b/package/libs/openssl/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssl
 PKG_BASE:=1.1.1
-PKG_BUGFIX:=i
+PKG_BUGFIX:=j
 PKG_VERSION:=$(PKG_BASE)$(PKG_BUGFIX)
 PKG_RELEASE:=1
 PKG_USE_MIPS16:=0
@@ -25,7 +25,7 @@ PKG_SOURCE_URL:= \
 	ftp://ftp.pca.dfn.de/pub/tools/net/openssl/source/ \
 	https://www.openssl.org/source/ \
 	https://www.openssl.org/source/old/$(PKG_BASE)/
-PKG_HASH:=e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242
+PKG_HASH:=aaf2fcb575cdf6491b98ab4829abf78a3dec8402b8b81efc8f23c00d443981bf
 
 PKG_LICENSE:=OpenSSL
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
This fixes 4 security vulnerabilities/bugs:

- CVE-2021-2839 - SSLv2 vulnerability. Openssl 1.1.1 does not support
  SSLv2, but the affected functions still exist. Considered just a bug.

- CVE-2021-2840 - calls EVP_CipherUpdate, EVP_EncryptUpdate and
  EVP_DecryptUpdate may overflow the output length argument in some
  cases where the input length is close to the maximum permissable
  length for an integer on the platform. In such cases the return value
  from the function call will be 1 (indicating success), but the output
  length value will be negative.

- CVE-2021-2841 - The X509_issuer_and_serial_hash() function attempts to
  create a unique hash value based on the issuer and serial number data
  contained within an X509 certificate. However it was failing to
  correctly handle any errors that may occur while parsing the issuer
  field (which might occur if the issuer field is maliciously
  constructed). This may subsequently result in a NULL pointer deref and
  a crash leading to a potential denial of service attack.

- Fixed SRP_Calc_client_key so that it runs in constant time. This could
  be exploited in a side channel attack to recover the password.

The 3 CVEs above are currently awaiting analysis.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [ ] 我知道
