### PR TITLE
kernel: Adapt renamed can-dev.ko

### DIFF
--- a/package/kernel/linux/modules/can.mk
+++ b/package/kernel/linux/modules/can.mk
@@ -28,7 +28,8 @@ define KernelPackage/can
 	CONFIG_CAN_SOFTING=n \
 	CONFIG_NET_EMATCH_CANID=n \
 	CONFIG_CAN_DEBUG_DEVICES=n
-  FILES:=$(LINUX_DIR)/drivers/net/can/can-dev.ko \
+  FILES:=$(LINUX_DIR)/drivers/net/can/can-dev.ko@lt5.4 \
+	 $(LINUX_DIR)/drivers/net/can/dev/can-dev.ko@ge5.4 \
 	 $(LINUX_DIR)/net/can/can.ko
   AUTOLOAD:=$(call AutoProbe,can can-dev)
 endef


### PR DESCRIPTION
The can-dev.ko kernel module was moved in kernel 5.4.110 and 5.10.28.

Fixes: 5dcbd82 ("kernel: bump 5.4 to 5.4.110")
Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>
[Also compatible with kernel 4.x]
Signed-off-by: AmadeusGhost <amadeus@jmu.edu.cn>

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [ ] 我知道
