### PR TITLE
kernel: bump 5.4 to 5.4.124

### DIFF
--- a/include/kernel-version.mk
+++ b/include/kernel-version.mk
@@ -8,11 +8,11 @@ endif
 
 LINUX_VERSION-4.14 = .195
 LINUX_VERSION-4.19 = .138
-LINUX_VERSION-5.4 = .123
+LINUX_VERSION-5.4 = .124
 
 LINUX_KERNEL_HASH-4.14.195 = 394f28798670240baacd9e2cce521fbd79f8da5e1fc191695b0e11381445a021
 LINUX_KERNEL_HASH-4.19.138 = d15c27d05f6c527269b75b30cc72972748e55720e7e00ad8abbaa4fe3b1d5e02
-LINUX_KERNEL_HASH-5.4.123 = 8efe33fffb661d14422877b775fb38de373e04ad640f5d0c8f57144ddb1022de
+LINUX_KERNEL_HASH-5.4.124 = f7f29dda2b042d7b5986d18274413131cf70e17288c05e9a683df1f46c507d82
 
 remove_uri_prefix=$(subst git://,,$(subst http://,,$(subst https://,,$(1))))
 sanitize_uri=$(call qstrip,$(subst @,_,$(subst :,_,$(subst .,_,$(subst -,_,$(subst /,_,$(1)))))))

--- a/target/linux/ath79/patches-5.4/921-serial-core-add-support-for-boot-console-with-arbitr.patch
+++ b/target/linux/ath79/patches-5.4/921-serial-core-add-support-for-boot-console-with-arbitr.patch
@@ -30,7 +30,7 @@ Signed-off-by: Sungbo Eo <mans0n@gorani.run>
  			uport->cons->cflag = 0;
  		}
  		/*
-@@ -2108,8 +2110,10 @@ uart_set_options(struct uart_port *port,
+@@ -2110,8 +2112,10 @@ uart_set_options(struct uart_port *port,
  	 * Allow the setting of the UART parameters with a NULL console
  	 * too:
  	 */

--- a/target/linux/generic/backport-5.4/700-v5.5-net-core-allow-fast-GRO-for-skbs-with-Ethernet-heade.patch
+++ b/target/linux/generic/backport-5.4/700-v5.5-net-core-allow-fast-GRO-for-skbs-with-Ethernet-heade.patch
@@ -66,7 +66,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
 
 --- a/net/core/dev.c
 +++ b/net/core/dev.c
-@@ -5404,8 +5404,7 @@ static inline void skb_gro_reset_offset(
+@@ -5423,8 +5423,7 @@ static inline void skb_gro_reset_offset(
  	NAPI_GRO_CB(skb)->frag0 = NULL;
  	NAPI_GRO_CB(skb)->frag0_len = 0;
  

--- a/target/linux/generic/backport-5.4/745-v5.7-net-dsa-mt7530-add-support-for-port-mirroring.patch
+++ b/target/linux/generic/backport-5.4/745-v5.7-net-dsa-mt7530-add-support-for-port-mirroring.patch
@@ -17,7 +17,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
 
 --- a/drivers/net/dsa/mt7530.c
 +++ b/drivers/net/dsa/mt7530.c
-@@ -1153,6 +1153,64 @@ mt7530_port_vlan_del(struct dsa_switch *
+@@ -1145,6 +1145,64 @@ mt7530_port_vlan_del(struct dsa_switch *
  	return 0;
  }
  
@@ -82,7 +82,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  static enum dsa_tag_protocol
  mtk_get_tag_protocol(struct dsa_switch *ds, int port)
  {
-@@ -1530,6 +1588,8 @@ static const struct dsa_switch_ops mt753
+@@ -1522,6 +1580,8 @@ static const struct dsa_switch_ops mt753
  	.port_vlan_prepare	= mt7530_port_vlan_prepare,
  	.port_vlan_add		= mt7530_port_vlan_add,
  	.port_vlan_del		= mt7530_port_vlan_del,

--- a/target/linux/generic/backport-5.4/752-v5.8-net-dsa-provide-an-option-for-drivers-to-always-rece.patch
+++ b/target/linux/generic/backport-5.4/752-v5.8-net-dsa-provide-an-option-for-drivers-to-always-rece.patch
@@ -101,7 +101,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  		return 0;
  
  	/* Do not deprogram the CPU port as it may be shared with other user
-@@ -1118,7 +1118,7 @@ static int dsa_slave_vlan_rx_add_vid(str
+@@ -1120,7 +1120,7 @@ static int dsa_slave_vlan_rx_add_vid(str
  	 * need to emulate the switchdev prepare + commit phase.
  	 */
  	if (dp->bridge_dev) {
@@ -110,7 +110,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  			return 0;
  
  		/* br_vlan_get_info() returns -EINVAL or -ENOENT if the
-@@ -1152,7 +1152,7 @@ static int dsa_slave_vlan_rx_kill_vid(st
+@@ -1154,7 +1154,7 @@ static int dsa_slave_vlan_rx_kill_vid(st
  	 * need to emulate the switchdev prepare + commit phase.
  	 */
  	if (dp->bridge_dev) {

--- a/target/linux/generic/backport-5.4/753-v5.8-net-dsa-mt7530-fix-VLAN-setup.patch
+++ b/target/linux/generic/backport-5.4/753-v5.8-net-dsa-mt7530-fix-VLAN-setup.patch
@@ -15,7 +15,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
 
 --- a/drivers/net/dsa/mt7530.c
 +++ b/drivers/net/dsa/mt7530.c
-@@ -1093,12 +1093,6 @@ mt7530_port_vlan_add(struct dsa_switch *
+@@ -1085,12 +1085,6 @@ mt7530_port_vlan_add(struct dsa_switch *
  	struct mt7530_priv *priv = ds->priv;
  	u16 vid;
  
@@ -28,7 +28,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  	mutex_lock(&priv->reg_mutex);
  
  	for (vid = vlan->vid_begin; vid <= vlan->vid_end; ++vid) {
-@@ -1124,12 +1118,6 @@ mt7530_port_vlan_del(struct dsa_switch *
+@@ -1116,12 +1110,6 @@ mt7530_port_vlan_del(struct dsa_switch *
  	struct mt7530_priv *priv = ds->priv;
  	u16 vid, pvid;
  
@@ -41,7 +41,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  	mutex_lock(&priv->reg_mutex);
  
  	pvid = priv->ports[port].pvid;
-@@ -1242,6 +1230,7 @@ mt7530_setup(struct dsa_switch *ds)
+@@ -1234,6 +1222,7 @@ mt7530_setup(struct dsa_switch *ds)
  	 * as two netdev instances.
  	 */
  	dn = ds->ports[MT7530_CPU_PORT].master->dev.of_node->parent;

--- a/target/linux/generic/backport-5.4/760-net-ethernet-mediatek-Integrate-GDM-PSE-setup-operat.patch
+++ b/target/linux/generic/backport-5.4/760-net-ethernet-mediatek-Integrate-GDM-PSE-setup-operat.patch
@@ -10,7 +10,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
 
 --- a/drivers/net/ethernet/mediatek/mtk_eth_soc.c
 +++ b/drivers/net/ethernet/mediatek/mtk_eth_soc.c
-@@ -2211,6 +2211,28 @@ static int mtk_start_dma(struct mtk_eth
+@@ -2232,6 +2232,28 @@ static int mtk_start_dma(struct mtk_eth
  	return 0;
  }
  
@@ -39,7 +39,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  static int mtk_open(struct net_device *dev)
  {
  	struct mtk_mac *mac = netdev_priv(dev);
-@@ -2406,8 +2428,6 @@ static int mtk_hw_init(struct mtk_eth *e
+@@ -2427,8 +2449,6 @@ static int mtk_hw_init(struct mtk_eth *e
  	mtk_w32(eth, 0, MTK_QDMA_DELAY_INT);
  	mtk_tx_irq_disable(eth, ~0);
  	mtk_rx_irq_disable(eth, ~0);
@@ -48,7 +48,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  
  	/* FE int grouping */
  	mtk_w32(eth, MTK_TX_DONE_INT, MTK_PDMA_INT_GRP1);
-@@ -2416,18 +2436,7 @@ static int mtk_hw_init(struct mtk_eth *e
+@@ -2437,18 +2457,7 @@ static int mtk_hw_init(struct mtk_eth *e
  	mtk_w32(eth, MTK_RX_DONE_INT, MTK_QDMA_INT_GRP2);
  	mtk_w32(eth, 0x21021000, MTK_FE_INT_GRP);
  

--- a/target/linux/generic/backport-5.4/761-net-ethernet-mediatek-Refine-the-timing-of-GDM-PSE-s.patch
+++ b/target/linux/generic/backport-5.4/761-net-ethernet-mediatek-Refine-the-timing-of-GDM-PSE-s.patch
@@ -15,7 +15,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
 
 --- a/drivers/net/ethernet/mediatek/mtk_eth_soc.c
 +++ b/drivers/net/ethernet/mediatek/mtk_eth_soc.c
-@@ -2215,6 +2215,9 @@ static void mtk_gdm_config(struct mtk_et
+@@ -2236,6 +2236,9 @@ static void mtk_gdm_config(struct mtk_et
  {
  	int i;
  
@@ -25,7 +25,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  	for (i = 0; i < MTK_MAC_COUNT; i++) {
  		u32 val = mtk_r32(eth, MTK_GDMA_FWD_CFG(i));
  
-@@ -2253,6 +2256,8 @@ static int mtk_open(struct net_device *d
+@@ -2274,6 +2277,8 @@ static int mtk_open(struct net_device *d
  		if (err)
  			return err;
  
@@ -34,7 +34,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  		napi_enable(&eth->tx_napi);
  		napi_enable(&eth->rx_napi);
  		mtk_tx_irq_enable(eth, MTK_TX_DONE_INT);
-@@ -2436,8 +2441,6 @@ static int mtk_hw_init(struct mtk_eth *e
+@@ -2457,8 +2462,6 @@ static int mtk_hw_init(struct mtk_eth *e
  	mtk_w32(eth, MTK_RX_DONE_INT, MTK_QDMA_INT_GRP2);
  	mtk_w32(eth, 0x21021000, MTK_FE_INT_GRP);
  

--- a/target/linux/generic/backport-5.4/762-net-ethernet-mediatek-Enable-GDM-GDMA_DROP_ALL-mode.patch
+++ b/target/linux/generic/backport-5.4/762-net-ethernet-mediatek-Enable-GDM-GDMA_DROP_ALL-mode.patch
@@ -12,7 +12,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
 
 --- a/drivers/net/ethernet/mediatek/mtk_eth_soc.c
 +++ b/drivers/net/ethernet/mediatek/mtk_eth_soc.c
-@@ -2310,6 +2310,8 @@ static int mtk_stop(struct net_device *d
+@@ -2331,6 +2331,8 @@ static int mtk_stop(struct net_device *d
  	if (!refcount_dec_and_test(&eth->dma_refcnt))
  		return 0;
  

--- a/target/linux/generic/backport-5.4/771-v5.12-net-dsa-be-louder-when-a-non-legacy-FDB-operation-fa.patch
+++ b/target/linux/generic/backport-5.4/771-v5.12-net-dsa-be-louder-when-a-non-legacy-FDB-operation-fa.patch
@@ -25,7 +25,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
 
 --- a/net/dsa/slave.c
 +++ b/net/dsa/slave.c
-@@ -1590,7 +1590,9 @@ static void dsa_slave_switchdev_event_wo
+@@ -1592,7 +1592,9 @@ static void dsa_slave_switchdev_event_wo
  
  		err = dsa_port_fdb_add(dp, fdb_info->addr, fdb_info->vid);
  		if (err) {
@@ -36,7 +36,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  			break;
  		}
  		fdb_info->offloaded = true;
-@@ -1605,9 +1607,11 @@ static void dsa_slave_switchdev_event_wo
+@@ -1607,9 +1609,11 @@ static void dsa_slave_switchdev_event_wo
  
  		err = dsa_port_fdb_del(dp, fdb_info->addr, fdb_info->vid);
  		if (err) {

--- a/target/linux/generic/backport-5.4/772-v5.12-net-dsa-don-t-use-switchdev_notifier_fdb_info-in-dsa.patch
+++ b/target/linux/generic/backport-5.4/772-v5.12-net-dsa-don-t-use-switchdev_notifier_fdb_info-in-dsa.patch
@@ -54,7 +54,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  	struct sk_buff *	(*xmit)(struct sk_buff *skb,
 --- a/net/dsa/slave.c
 +++ b/net/dsa/slave.c
-@@ -1565,76 +1565,66 @@ static int dsa_slave_netdevice_event(str
+@@ -1567,76 +1567,66 @@ static int dsa_slave_netdevice_event(str
  	return NOTIFY_DONE;
  }
  
@@ -167,7 +167,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  }
  
  /* Called under rcu_read_lock() */
-@@ -1642,7 +1632,9 @@ static int dsa_slave_switchdev_event(str
+@@ -1644,7 +1634,9 @@ static int dsa_slave_switchdev_event(str
  				     unsigned long event, void *ptr)
  {
  	struct net_device *dev = switchdev_notifier_info_to_dev(ptr);
@@ -177,7 +177,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  	int err;
  
  	if (event == SWITCHDEV_PORT_ATTR_SET) {
-@@ -1655,20 +1647,32 @@ static int dsa_slave_switchdev_event(str
+@@ -1657,20 +1649,32 @@ static int dsa_slave_switchdev_event(str
  	if (!dsa_slave_dev_check(dev))
  		return NOTIFY_DONE;
  
@@ -213,7 +213,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  		dev_hold(dev);
  		break;
  	default:
-@@ -1678,10 +1682,6 @@ static int dsa_slave_switchdev_event(str
+@@ -1680,10 +1684,6 @@ static int dsa_slave_switchdev_event(str
  
  	dsa_schedule_work(&switchdev_work->work);
  	return NOTIFY_OK;

--- a/target/linux/generic/backport-5.4/773-v5.12-net-dsa-move-switchdev-event-implementation-under-th.patch
+++ b/target/linux/generic/backport-5.4/773-v5.12-net-dsa-move-switchdev-event-implementation-under-th.patch
@@ -20,7 +20,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
 
 --- a/net/dsa/slave.c
 +++ b/net/dsa/slave.c
-@@ -1637,31 +1637,29 @@ static int dsa_slave_switchdev_event(str
+@@ -1639,31 +1639,29 @@ static int dsa_slave_switchdev_event(str
  	struct dsa_port *dp;
  	int err;
  
@@ -68,7 +68,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  		fdb_info = ptr;
  
  		if (!fdb_info->added_by_user) {
-@@ -1674,13 +1672,12 @@ static int dsa_slave_switchdev_event(str
+@@ -1676,13 +1674,12 @@ static int dsa_slave_switchdev_event(str
  		switchdev_work->vid = fdb_info->vid;
  
  		dev_hold(dev);

--- a/target/linux/generic/backport-5.4/774-v5.12-net-dsa-exit-early-in-dsa_slave_switchdev_event-if-w.patch
+++ b/target/linux/generic/backport-5.4/774-v5.12-net-dsa-exit-early-in-dsa_slave_switchdev_event-if-w.patch
@@ -30,7 +30,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
 
 --- a/net/dsa/slave.c
 +++ b/net/dsa/slave.c
-@@ -1650,6 +1650,9 @@ static int dsa_slave_switchdev_event(str
+@@ -1652,6 +1652,9 @@ static int dsa_slave_switchdev_event(str
  
  		dp = dsa_slave_to_port(dev);
  

--- a/target/linux/generic/backport-5.4/775-v5.12-net-dsa-listen-for-SWITCHDEV_-FDB-DEL-_ADD_TO_DEVICE.patch
+++ b/target/linux/generic/backport-5.4/775-v5.12-net-dsa-listen-for-SWITCHDEV_-FDB-DEL-_ADD_TO_DEVICE.patch
@@ -172,7 +172,7 @@ Signed-off-by: DENG Qingfang <dqfext@gmail.com>
  	 */
 --- a/net/dsa/slave.c
 +++ b/net/dsa/slave.c
-@@ -1627,6 +1627,25 @@ static void dsa_slave_switchdev_event_wo
+@@ -1629,6 +1629,25 @@ static void dsa_slave_switchdev_event_wo
  		dev_put(dp->slave);
  }
  
@@ -198,7 +198,7 @@ Signed-off-by: DENG Qingfang <dqfext@gmail.com>
  /* Called under rcu_read_lock() */
  static int dsa_slave_switchdev_event(struct notifier_block *unused,
  				     unsigned long event, void *ptr)
-@@ -1645,10 +1664,37 @@ static int dsa_slave_switchdev_event(str
+@@ -1647,10 +1666,37 @@ static int dsa_slave_switchdev_event(str
  		return notifier_from_errno(err);
  	case SWITCHDEV_FDB_ADD_TO_DEVICE:
  	case SWITCHDEV_FDB_DEL_TO_DEVICE:
@@ -239,7 +239,7 @@ Signed-off-by: DENG Qingfang <dqfext@gmail.com>
  
  		if (!dp->ds->ops->port_fdb_add || !dp->ds->ops->port_fdb_del)
  			return NOTIFY_DONE;
-@@ -1663,18 +1709,13 @@ static int dsa_slave_switchdev_event(str
+@@ -1665,18 +1711,13 @@ static int dsa_slave_switchdev_event(str
  		switchdev_work->port = dp->index;
  		switchdev_work->event = event;
  

--- a/target/linux/generic/hack-5.4/661-use_fq_codel_by_default.patch
+++ b/target/linux/generic/hack-5.4/661-use_fq_codel_by_default.patch
@@ -14,7 +14,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 
 --- a/include/net/sch_generic.h
 +++ b/include/net/sch_generic.h
-@@ -570,12 +570,13 @@ extern struct Qdisc_ops noop_qdisc_ops;
+@@ -603,12 +603,13 @@ extern struct Qdisc_ops noop_qdisc_ops;
  extern struct Qdisc_ops pfifo_fast_ops;
  extern struct Qdisc_ops mq_qdisc_ops;
  extern struct Qdisc_ops noqueue_qdisc_ops;
@@ -82,8 +82,8 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 +const struct Qdisc_ops *default_qdisc_ops = &fq_codel_qdisc_ops;
  EXPORT_SYMBOL(default_qdisc_ops);
  
- /* Main transmission queue. */
-@@ -1035,12 +1035,12 @@ static void attach_one_default_qdisc(str
+ static void qdisc_maybe_clear_missed(struct Qdisc *q,
+@@ -1079,12 +1079,12 @@ static void attach_one_default_qdisc(str
  				     void *_unused)
  {
  	struct Qdisc *qdisc;

--- a/target/linux/generic/hack-5.4/662-remove_pfifo_fast.patch
+++ b/target/linux/generic/hack-5.4/662-remove_pfifo_fast.patch
@@ -10,7 +10,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 
 --- a/net/sched/sch_generic.c
 +++ b/net/sched/sch_generic.c
-@@ -595,211 +595,6 @@ struct Qdisc_ops noqueue_qdisc_ops __rea
+@@ -620,230 +620,6 @@ struct Qdisc_ops noqueue_qdisc_ops __rea
  	.owner		=	THIS_MODULE,
  };
  
@@ -64,8 +64,10 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 -{
 -	struct pfifo_fast_priv *priv = qdisc_priv(qdisc);
 -	struct sk_buff *skb = NULL;
+-	bool need_retry = true;
 -	int band;
 -
+-retry:
 -	for (band = 0; band < PFIFO_FAST_BANDS && !skb; band++) {
 -		struct skb_array *q = band2list(priv, band);
 -
@@ -76,6 +78,23 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 -	}
 -	if (likely(skb)) {
 -		qdisc_update_stats_at_dequeue(qdisc, skb);
+-	} else if (need_retry &&
+-		   test_bit(__QDISC_STATE_MISSED, &qdisc->state)) {
+-		/* Delay clearing the STATE_MISSED here to reduce
+-		 * the overhead of the second spin_trylock() in
+-		 * qdisc_run_begin() and __netif_schedule() calling
+-		 * in qdisc_run_end().
+-		 */
+-		clear_bit(__QDISC_STATE_MISSED, &qdisc->state);
+-
+-		/* Make sure dequeuing happens after clearing
+-		 * STATE_MISSED.
+-		 */
+-		smp_mb__after_atomic();
+-
+-		need_retry = false;
+-
+-		goto retry;
 -	} else {
 -		WRITE_ONCE(qdisc->empty, true);
 -	}

--- a/target/linux/generic/pending-5.4/647-net-dsa-support-hardware-flow-table-offload.patch
+++ b/target/linux/generic/pending-5.4/647-net-dsa-support-hardware-flow-table-offload.patch
@@ -38,7 +38,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  
  #include "dsa_priv.h"
  
-@@ -1221,6 +1225,27 @@ static struct devlink_port *dsa_slave_ge
+@@ -1223,6 +1227,27 @@ static struct devlink_port *dsa_slave_ge
  	return dp->ds->devlink ? &dp->devlink_port : NULL;
  }
  
@@ -66,7 +66,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  static const struct net_device_ops dsa_slave_netdev_ops = {
  	.ndo_open	 	= dsa_slave_open,
  	.ndo_stop		= dsa_slave_close,
-@@ -1245,6 +1270,9 @@ static const struct net_device_ops dsa_s
+@@ -1247,6 +1272,9 @@ static const struct net_device_ops dsa_s
  	.ndo_vlan_rx_add_vid	= dsa_slave_vlan_rx_add_vid,
  	.ndo_vlan_rx_kill_vid	= dsa_slave_vlan_rx_kill_vid,
  	.ndo_get_devlink_port	= dsa_slave_get_devlink_port,

--- a/target/linux/generic/pending-5.4/680-NET-skip-GRO-for-foreign-MAC-addresses.patch
+++ b/target/linux/generic/pending-5.4/680-NET-skip-GRO-for-foreign-MAC-addresses.patch
@@ -32,7 +32,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	__u16			tc_index;	/* traffic control index */
 --- a/net/core/dev.c
 +++ b/net/core/dev.c
-@@ -5470,6 +5470,9 @@ static enum gro_result dev_gro_receive(s
+@@ -5489,6 +5489,9 @@ static enum gro_result dev_gro_receive(s
  	int same_flow;
  	int grow;
  
@@ -42,7 +42,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	if (netif_elide_gro(skb->dev))
  		goto normal;
  
-@@ -7265,6 +7268,48 @@ static void __netdev_adjacent_dev_unlink
+@@ -7284,6 +7287,48 @@ static void __netdev_adjacent_dev_unlink
  					   &upper_dev->adj_list.lower);
  }
  
@@ -91,7 +91,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  static int __netdev_upper_dev_link(struct net_device *dev,
  				   struct net_device *upper_dev, bool master,
  				   void *upper_priv, void *upper_info,
-@@ -7315,6 +7360,7 @@ static int __netdev_upper_dev_link(struc
+@@ -7334,6 +7379,7 @@ static int __netdev_upper_dev_link(struc
  	if (ret)
  		return ret;
  
@@ -99,7 +99,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	ret = call_netdevice_notifiers_info(NETDEV_CHANGEUPPER,
  					    &changeupper_info.info);
  	ret = notifier_to_errno(ret);
-@@ -7408,6 +7454,7 @@ void netdev_upper_dev_unlink(struct net_
+@@ -7427,6 +7473,7 @@ void netdev_upper_dev_unlink(struct net_
  
  	__netdev_adjacent_dev_unlink_neighbour(dev, upper_dev);
  
@@ -107,7 +107,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	call_netdevice_notifiers_info(NETDEV_CHANGEUPPER,
  				      &changeupper_info.info);
  
-@@ -8138,6 +8185,7 @@ int dev_set_mac_address(struct net_devic
+@@ -8157,6 +8204,7 @@ int dev_set_mac_address(struct net_devic
  	if (err)
  		return err;
  	dev->addr_assign_type = NET_ADDR_SET;

--- a/target/linux/generic/pending-5.4/690-net-add-support-for-threaded-NAPI-polling.patch
+++ b/target/linux/generic/pending-5.4/690-net-add-support-for-threaded-NAPI-polling.patch
@@ -95,7 +95,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  
  static int netif_rx_internal(struct sk_buff *skb);
  static int call_netdevice_notifiers_info(unsigned long val,
-@@ -5912,6 +5913,11 @@ void __napi_schedule(struct napi_struct
+@@ -5931,6 +5932,11 @@ void __napi_schedule(struct napi_struct
  {
  	unsigned long flags;
  
@@ -107,7 +107,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	local_irq_save(flags);
  	____napi_schedule(this_cpu_ptr(&softnet_data), n);
  	local_irq_restore(flags);
-@@ -5959,6 +5965,11 @@ EXPORT_SYMBOL(napi_schedule_prep);
+@@ -5978,6 +5984,11 @@ EXPORT_SYMBOL(napi_schedule_prep);
   */
  void __napi_schedule_irqoff(struct napi_struct *n)
  {
@@ -119,7 +119,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	____napi_schedule(this_cpu_ptr(&softnet_data), n);
  }
  EXPORT_SYMBOL(__napi_schedule_irqoff);
-@@ -6220,9 +6231,89 @@ static void init_gro_hash(struct napi_st
+@@ -6239,9 +6250,89 @@ static void init_gro_hash(struct napi_st
  	napi->gro_bitmask = 0;
  }
  
@@ -209,7 +209,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	INIT_LIST_HEAD(&napi->poll_list);
  	hrtimer_init(&napi->timer, CLOCK_MONOTONIC, HRTIMER_MODE_REL_PINNED);
  	napi->timer.function = napi_watchdog;
-@@ -6239,6 +6330,7 @@ void netif_napi_add(struct net_device *d
+@@ -6258,6 +6349,7 @@ void netif_napi_add(struct net_device *d
  #ifdef CONFIG_NETPOLL
  	napi->poll_owner = -1;
  #endif
@@ -217,7 +217,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	set_bit(NAPI_STATE_SCHED, &napi->state);
  	set_bit(NAPI_STATE_NPSVC, &napi->state);
  	list_add_rcu(&napi->dev_list, &dev->napi_list);
-@@ -6279,6 +6371,7 @@ static void flush_gro_hash(struct napi_s
+@@ -6298,6 +6390,7 @@ static void flush_gro_hash(struct napi_s
  void netif_napi_del(struct napi_struct *napi)
  {
  	might_sleep();
@@ -225,7 +225,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	if (napi_hash_del(napi))
  		synchronize_net();
  	list_del_init(&napi->dev_list);
-@@ -6291,50 +6384,18 @@ EXPORT_SYMBOL(netif_napi_del);
+@@ -6310,50 +6403,18 @@ EXPORT_SYMBOL(netif_napi_del);
  
  static int napi_poll(struct napi_struct *n, struct list_head *repoll)
  {
@@ -280,7 +280,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  
  	/* Some drivers may have called napi_schedule
  	 * prior to exhausting their budget.
-@@ -10314,6 +10375,10 @@ static int __init net_dev_init(void)
+@@ -10333,6 +10394,10 @@ static int __init net_dev_init(void)
  		sd->backlog.weight = weight_p;
  	}
  

--- a/target/linux/generic/pending-5.4/761-net-dsa-mt7530-Support-EEE-features.patch
+++ b/target/linux/generic/pending-5.4/761-net-dsa-mt7530-Support-EEE-features.patch
@@ -9,7 +9,7 @@ Content-Transfer-Encoding: 8bit
 Signed-off-by: René van Dorst <opensource@vdorst.com>
 --- a/drivers/net/dsa/mt7530.c
 +++ b/drivers/net/dsa/mt7530.c
-@@ -1419,9 +1419,13 @@ static void mt7530_phylink_mac_config(st
+@@ -1409,9 +1409,13 @@ static void mt7530_phylink_mac_config(st
  	switch (state->speed) {
  	case SPEED_1000:
  		mcr_new |= PMCR_FORCE_SPEED_1000;
@@ -23,7 +23,7 @@ Signed-off-by: René van Dorst <opensource@vdorst.com>
  		break;
  	}
  	if (state->duplex == DUPLEX_FULL) {
-@@ -1557,6 +1561,54 @@ mt7530_phylink_mac_link_state(struct dsa
+@@ -1547,6 +1551,54 @@ mt7530_phylink_mac_link_state(struct dsa
  	return 1;
  }
  
@@ -78,7 +78,7 @@ Signed-off-by: René van Dorst <opensource@vdorst.com>
  static const struct dsa_switch_ops mt7530_switch_ops = {
  	.get_tag_protocol	= mtk_get_tag_protocol,
  	.setup			= mt7530_setup,
-@@ -1584,6 +1636,8 @@ static const struct dsa_switch_ops mt753
+@@ -1574,6 +1626,8 @@ static const struct dsa_switch_ops mt753
  	.phylink_mac_config	= mt7530_phylink_mac_config,
  	.phylink_mac_link_down	= mt7530_phylink_mac_link_down,
  	.phylink_mac_link_up	= mt7530_phylink_mac_link_up,

--- a/target/linux/generic/pending-5.4/765-net-dsa-Include-local-addresses-in-assisted-CPU-port.patch
+++ b/target/linux/generic/pending-5.4/765-net-dsa-Include-local-addresses-in-assisted-CPU-port.patch
@@ -18,7 +18,7 @@ Signed-off-by: Tobias Waldekranz <tobias@waldekranz.com>
 
 --- a/net/dsa/slave.c
 +++ b/net/dsa/slave.c
-@@ -1695,10 +1695,12 @@ static int dsa_slave_switchdev_event(str
+@@ -1697,10 +1697,12 @@ static int dsa_slave_switchdev_event(str
  		fdb_info = ptr;
  
  		if (dsa_slave_dev_check(dev)) {

--- a/target/linux/generic/pending-5.4/766-net-dsa-Include-bridge-addresses-in-assisted-CPU-por.patch
+++ b/target/linux/generic/pending-5.4/766-net-dsa-Include-bridge-addresses-in-assisted-CPU-por.patch
@@ -15,7 +15,7 @@ Signed-off-by: Tobias Waldekranz <tobias@waldekranz.com>
 
 --- a/net/dsa/slave.c
 +++ b/net/dsa/slave.c
-@@ -1709,7 +1709,11 @@ static int dsa_slave_switchdev_event(str
+@@ -1711,7 +1711,11 @@ static int dsa_slave_switchdev_event(str
  			struct net_device *br_dev;
  			struct dsa_slave_priv *p;
  

--- a/target/linux/generic/pending-5.4/767-net-dsa-Sync-static-FDB-entries-on-foreign-interface.patch
+++ b/target/linux/generic/pending-5.4/767-net-dsa-Sync-static-FDB-entries-on-foreign-interface.patch
@@ -28,7 +28,7 @@ Signed-off-by: Tobias Waldekranz <tobias@waldekranz.com>
 
 --- a/net/dsa/slave.c
 +++ b/net/dsa/slave.c
-@@ -1702,9 +1702,12 @@ static int dsa_slave_switchdev_event(str
+@@ -1704,9 +1704,12 @@ static int dsa_slave_switchdev_event(str
  			else if (!fdb_info->added_by_user)
  				return NOTIFY_OK;
  		} else {
@@ -44,7 +44,7 @@ Signed-off-by: Tobias Waldekranz <tobias@waldekranz.com>
  			 */
  			struct net_device *br_dev;
  			struct dsa_slave_priv *p;
-@@ -1726,7 +1729,8 @@ static int dsa_slave_switchdev_event(str
+@@ -1728,7 +1731,8 @@ static int dsa_slave_switchdev_event(str
  
  			dp = p->dp->cpu_dp;
  

--- a/target/linux/generic/pending-5.4/770-00-net-ethernet-mtk_eth_soc-use-napi_consume_skb.patch
+++ b/target/linux/generic/pending-5.4/770-00-net-ethernet-mtk_eth_soc-use-napi_consume_skb.patch
@@ -9,7 +9,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 
 --- a/drivers/net/ethernet/mediatek/mtk_eth_soc.c
 +++ b/drivers/net/ethernet/mediatek/mtk_eth_soc.c
-@@ -853,7 +853,8 @@ static int txd_to_idx(struct mtk_tx_ring
+@@ -874,7 +874,8 @@ static int txd_to_idx(struct mtk_tx_ring
  	return ((void *)dma - (void *)ring->dma) / sizeof(*dma);
  }
  
@@ -19,7 +19,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  {
  	if (MTK_HAS_CAPS(eth->soc->caps, MTK_QDMA)) {
  		if (tx_buf->flags & MTK_TX_FLAGS_SINGLE0) {
-@@ -885,8 +886,12 @@ static void mtk_tx_unmap(struct mtk_eth
+@@ -906,8 +907,12 @@ static void mtk_tx_unmap(struct mtk_eth
  
  	tx_buf->flags = 0;
  	if (tx_buf->skb &&
@@ -34,7 +34,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	tx_buf->skb = NULL;
  }
  
-@@ -1064,7 +1069,7 @@ err_dma:
+@@ -1085,7 +1090,7 @@ err_dma:
  		tx_buf = mtk_desc_to_tx_buf(ring, itxd);
  
  		/* unmap dma */
@@ -43,7 +43,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  
  		itxd->txd3 = TX_DMA_LS0 | TX_DMA_OWNER_CPU;
  		if (!MTK_HAS_CAPS(eth->soc->caps, MTK_QDMA))
-@@ -1382,7 +1387,7 @@ static int mtk_poll_tx_qdma(struct mtk_e
+@@ -1403,7 +1408,7 @@ static int mtk_poll_tx_qdma(struct mtk_e
  			done[mac]++;
  			budget--;
  		}
@@ -52,7 +52,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  
  		ring->last_free = desc;
  		atomic_inc(&ring->free_count);
-@@ -1419,7 +1424,7 @@ static int mtk_poll_tx_pdma(struct mtk_e
+@@ -1440,7 +1445,7 @@ static int mtk_poll_tx_pdma(struct mtk_e
  			budget--;
  		}
  
@@ -61,7 +61,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  
  		desc = &ring->dma[cpu];
  		ring->last_free = desc;
-@@ -1621,7 +1626,7 @@ static void mtk_tx_clean(struct mtk_eth
+@@ -1642,7 +1647,7 @@ static void mtk_tx_clean(struct mtk_eth
  
  	if (ring->buf) {
  		for (i = 0; i < MTK_DMA_SIZE; i++)

--- a/target/linux/generic/pending-5.4/770-03-net-ethernet-mtk_eth_soc-fix-unnecessary-tx-queue-st.patch
+++ b/target/linux/generic/pending-5.4/770-03-net-ethernet-mtk_eth_soc-fix-unnecessary-tx-queue-st.patch
@@ -12,7 +12,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 
 --- a/drivers/net/ethernet/mediatek/mtk_eth_soc.c
 +++ b/drivers/net/ethernet/mediatek/mtk_eth_soc.c
-@@ -1126,17 +1126,6 @@ static void mtk_wake_queue(struct mtk_et
+@@ -1147,17 +1147,6 @@ static void mtk_wake_queue(struct mtk_et
  	}
  }
  
@@ -30,7 +30,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  static int mtk_start_xmit(struct sk_buff *skb, struct net_device *dev)
  {
  	struct mtk_mac *mac = netdev_priv(dev);
-@@ -1157,7 +1146,7 @@ static int mtk_start_xmit(struct sk_buff
+@@ -1178,7 +1167,7 @@ static int mtk_start_xmit(struct sk_buff
  
  	tx_num = mtk_cal_txd_req(skb);
  	if (unlikely(atomic_read(&ring->free_count) <= tx_num)) {
@@ -39,7 +39,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  		netif_err(eth, tx_queued, dev,
  			  "Tx Ring full when queue awake!\n");
  		spin_unlock(&eth->page_lock);
-@@ -1183,7 +1172,7 @@ static int mtk_start_xmit(struct sk_buff
+@@ -1204,7 +1193,7 @@ static int mtk_start_xmit(struct sk_buff
  		goto drop;
  
  	if (unlikely(atomic_read(&ring->free_count) <= ring->thresh))

--- a/target/linux/generic/pending-5.4/770-04-net-ethernet-mtk_eth_soc-use-larger-burst-size-for-q.patch
+++ b/target/linux/generic/pending-5.4/770-04-net-ethernet-mtk_eth_soc-use-larger-burst-size-for-q.patch
@@ -10,7 +10,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 
 --- a/drivers/net/ethernet/mediatek/mtk_eth_soc.c
 +++ b/drivers/net/ethernet/mediatek/mtk_eth_soc.c
-@@ -2187,7 +2187,7 @@ static int mtk_start_dma(struct mtk_eth
+@@ -2208,7 +2208,7 @@ static int mtk_start_dma(struct mtk_eth
  	if (MTK_HAS_CAPS(eth->soc->caps, MTK_QDMA)) {
  		mtk_w32(eth,
  			MTK_TX_WB_DDONE | MTK_TX_DMA_EN |

--- a/target/linux/generic/pending-5.4/770-06-net-ethernet-mtk_eth_soc-implement-dynamic-interrupt.patch
+++ b/target/linux/generic/pending-5.4/770-06-net-ethernet-mtk_eth_soc-implement-dynamic-interrupt.patch
@@ -20,7 +20,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	  MediaTek SoC family.
 --- a/drivers/net/ethernet/mediatek/mtk_eth_soc.c
 +++ b/drivers/net/ethernet/mediatek/mtk_eth_soc.c
-@@ -1228,12 +1228,13 @@ static void mtk_update_rx_cpu_idx(struct
+@@ -1249,12 +1249,13 @@ static void mtk_update_rx_cpu_idx(struct
  static int mtk_poll_rx(struct napi_struct *napi, int budget,
  		       struct mtk_eth *eth)
  {
@@ -35,7 +35,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  
  	while (done < budget) {
  		struct net_device *netdev;
-@@ -1307,6 +1308,7 @@ static int mtk_poll_rx(struct napi_struc
+@@ -1328,6 +1329,7 @@ static int mtk_poll_rx(struct napi_struc
  		else
  			skb_checksum_none_assert(skb);
  		skb->protocol = eth_type_trans(skb, netdev);
@@ -43,7 +43,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  
  		if (netdev->features & NETIF_F_HW_VLAN_CTAG_RX &&
  		    (trxd.rxd2 & RX_DMA_VTAG))
-@@ -1338,6 +1340,12 @@ rx_done:
+@@ -1359,6 +1361,12 @@ rx_done:
  		mtk_update_rx_cpu_idx(eth);
  	}
  
@@ -56,7 +56,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	return done;
  }
  
-@@ -1430,6 +1438,7 @@ static int mtk_poll_tx_pdma(struct mtk_e
+@@ -1451,6 +1459,7 @@ static int mtk_poll_tx_pdma(struct mtk_e
  static int mtk_poll_tx(struct mtk_eth *eth, int budget)
  {
  	struct mtk_tx_ring *ring = &eth->tx_ring;
@@ -64,7 +64,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	unsigned int done[MTK_MAX_DEVS];
  	unsigned int bytes[MTK_MAX_DEVS];
  	int total = 0, i;
-@@ -1447,8 +1456,14 @@ static int mtk_poll_tx(struct mtk_eth *e
+@@ -1468,8 +1477,14 @@ static int mtk_poll_tx(struct mtk_eth *e
  			continue;
  		netdev_completed_queue(eth->netdev[i], done[i], bytes[i]);
  		total += done[i];
@@ -79,7 +79,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	if (mtk_queue_stopped(eth) &&
  	    (atomic_read(&ring->free_count) > ring->thresh))
  		mtk_wake_queue(eth);
-@@ -2123,6 +2138,7 @@ static irqreturn_t mtk_handle_irq_rx(int
+@@ -2144,6 +2159,7 @@ static irqreturn_t mtk_handle_irq_rx(int
  {
  	struct mtk_eth *eth = _eth;
  
@@ -87,7 +87,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	if (likely(napi_schedule_prep(&eth->rx_napi))) {
  		__napi_schedule(&eth->rx_napi);
  		mtk_rx_irq_disable(eth, MTK_RX_DONE_INT);
-@@ -2135,6 +2151,7 @@ static irqreturn_t mtk_handle_irq_tx(int
+@@ -2156,6 +2172,7 @@ static irqreturn_t mtk_handle_irq_tx(int
  {
  	struct mtk_eth *eth = _eth;
  
@@ -95,7 +95,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	if (likely(napi_schedule_prep(&eth->tx_napi))) {
  		__napi_schedule(&eth->tx_napi);
  		mtk_tx_irq_disable(eth, MTK_TX_DONE_INT);
-@@ -2311,6 +2328,9 @@ static int mtk_stop(struct net_device *d
+@@ -2332,6 +2349,9 @@ static int mtk_stop(struct net_device *d
  	napi_disable(&eth->tx_napi);
  	napi_disable(&eth->rx_napi);
  
@@ -105,7 +105,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	if (MTK_HAS_CAPS(eth->soc->caps, MTK_QDMA))
  		mtk_stop_dma(eth, MTK_QDMA_GLO_CFG);
  	mtk_stop_dma(eth, MTK_PDMA_GLO_CFG);
-@@ -2360,6 +2380,64 @@ err_disable_clks:
+@@ -2381,6 +2401,64 @@ err_disable_clks:
  	return ret;
  }
  
@@ -170,7 +170,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  static int mtk_hw_init(struct mtk_eth *eth)
  {
  	int i, val, ret;
-@@ -2381,9 +2459,6 @@ static int mtk_hw_init(struct mtk_eth *e
+@@ -2402,9 +2480,6 @@ static int mtk_hw_init(struct mtk_eth *e
  			goto err_disable_pm;
  		}
  
@@ -180,7 +180,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  		/* disable delay and normal interrupt */
  		mtk_tx_irq_disable(eth, ~0);
  		mtk_rx_irq_disable(eth, ~0);
-@@ -2422,11 +2497,10 @@ static int mtk_hw_init(struct mtk_eth *e
+@@ -2443,11 +2518,10 @@ static int mtk_hw_init(struct mtk_eth *e
  	/* Enable RX VLan Offloading */
  	mtk_w32(eth, 1, MTK_CDMP_EG_CTRL);
  
@@ -194,7 +194,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	mtk_tx_irq_disable(eth, ~0);
  	mtk_rx_irq_disable(eth, ~0);
  
-@@ -2930,6 +3004,13 @@ static int mtk_probe(struct platform_dev
+@@ -2951,6 +3025,13 @@ static int mtk_probe(struct platform_dev
  	spin_lock_init(&eth->page_lock);
  	spin_lock_init(&eth->tx_irq_lock);
  	spin_lock_init(&eth->rx_irq_lock);
@@ -260,7 +260,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  
  /* QDMA Interrupt grouping registers */
  #define MTK_QDMA_INT_GRP1	0x1a20
-@@ -892,6 +898,18 @@ struct mtk_eth {
+@@ -912,6 +918,18 @@ struct mtk_eth {
  
  	const struct mtk_soc_data	*soc;
  

--- a/target/linux/generic/pending-5.4/770-08-net-ethernet-mtk_eth_soc-cache-hardware-pointer-of-l.patch
+++ b/target/linux/generic/pending-5.4/770-08-net-ethernet-mtk_eth_soc-cache-hardware-pointer-of-l.patch
@@ -11,7 +11,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 
 --- a/drivers/net/ethernet/mediatek/mtk_eth_soc.c
 +++ b/drivers/net/ethernet/mediatek/mtk_eth_soc.c
-@@ -1358,7 +1358,7 @@ static int mtk_poll_tx_qdma(struct mtk_e
+@@ -1379,7 +1379,7 @@ static int mtk_poll_tx_qdma(struct mtk_e
  	struct mtk_tx_buf *tx_buf;
  	u32 cpu, dma;
  
@@ -20,7 +20,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	dma = mtk_r32(eth, MTK_QTX_DRX_PTR);
  
  	desc = mtk_qdma_phys_to_virt(ring, cpu);
-@@ -1392,6 +1392,7 @@ static int mtk_poll_tx_qdma(struct mtk_e
+@@ -1413,6 +1413,7 @@ static int mtk_poll_tx_qdma(struct mtk_e
  		cpu = next_cpu;
  	}
  
@@ -28,7 +28,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	mtk_w32(eth, cpu, MTK_QTX_CRX_PTR);
  
  	return budget;
-@@ -1592,6 +1593,7 @@ static int mtk_tx_alloc(struct mtk_eth *
+@@ -1613,6 +1614,7 @@ static int mtk_tx_alloc(struct mtk_eth *
  	atomic_set(&ring->free_count, MTK_DMA_SIZE - 2);
  	ring->next_free = &ring->dma[0];
  	ring->last_free = &ring->dma[MTK_DMA_SIZE - 1];
@@ -36,7 +36,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	ring->thresh = MAX_SKB_FRAGS;
  
  	/* make sure that all changes to the dma ring are flushed before we
-@@ -1605,9 +1607,7 @@ static int mtk_tx_alloc(struct mtk_eth *
+@@ -1626,9 +1628,7 @@ static int mtk_tx_alloc(struct mtk_eth *
  		mtk_w32(eth,
  			ring->phys + ((MTK_DMA_SIZE - 1) * sz),
  			MTK_QTX_CRX_PTR);
@@ -49,7 +49,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	} else {
 --- a/drivers/net/ethernet/mediatek/mtk_eth_soc.h
 +++ b/drivers/net/ethernet/mediatek/mtk_eth_soc.h
-@@ -624,6 +624,7 @@ struct mtk_tx_buf {
+@@ -644,6 +644,7 @@ struct mtk_tx_buf {
   * @phys:		The physical addr of tx_buf
   * @next_free:		Pointer to the next free descriptor
   * @last_free:		Pointer to the last free descriptor
@@ -57,7 +57,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
   * @thresh:		The threshold of minimum amount of free descriptors
   * @free_count:		QDMA uses a linked list. Track how many free descriptors
   *			are present
-@@ -634,6 +635,7 @@ struct mtk_tx_ring {
+@@ -654,6 +655,7 @@ struct mtk_tx_ring {
  	dma_addr_t phys;
  	struct mtk_tx_dma *next_free;
  	struct mtk_tx_dma *last_free;

--- a/target/linux/generic/pending-5.4/770-09-net-ethernet-mtk_eth_soc-only-read-the-full-rx-descr.patch
+++ b/target/linux/generic/pending-5.4/770-09-net-ethernet-mtk_eth_soc-only-read-the-full-rx-descr.patch
@@ -11,7 +11,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 
 --- a/drivers/net/ethernet/mediatek/mtk_eth_soc.c
 +++ b/drivers/net/ethernet/mediatek/mtk_eth_soc.c
-@@ -772,13 +772,18 @@ static inline int mtk_max_buf_size(int f
+@@ -793,13 +793,18 @@ static inline int mtk_max_buf_size(int f
  	return buf_size;
  }
  
@@ -32,7 +32,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  }
  
  /* the qdma core needs scratch memory to be setup */
-@@ -1250,8 +1255,7 @@ static int mtk_poll_rx(struct napi_struc
+@@ -1271,8 +1276,7 @@ static int mtk_poll_rx(struct napi_struc
  		rxd = &ring->dma[idx];
  		data = ring->data[idx];
  

--- a/target/linux/generic/pending-5.4/770-10-net-ethernet-mtk_eth_soc-unmap-rx-data-before-callin.patch
+++ b/target/linux/generic/pending-5.4/770-10-net-ethernet-mtk_eth_soc-unmap-rx-data-before-callin.patch
@@ -11,7 +11,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 
 --- a/drivers/net/ethernet/mediatek/mtk_eth_soc.c
 +++ b/drivers/net/ethernet/mediatek/mtk_eth_soc.c
-@@ -1293,17 +1293,18 @@ static int mtk_poll_rx(struct napi_struc
+@@ -1314,17 +1314,18 @@ static int mtk_poll_rx(struct napi_struc
  			goto release_desc;
  		}
  
@@ -34,7 +34,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  		pktlen = RX_DMA_GET_PLEN0(trxd.rxd2);
  		skb->dev = netdev;
  		skb_put(skb, pktlen);
-@@ -1321,6 +1322,7 @@ static int mtk_poll_rx(struct napi_struc
+@@ -1342,6 +1343,7 @@ static int mtk_poll_rx(struct napi_struc
  		skb_record_rx_queue(skb, 0);
  		napi_gro_receive(napi, skb);
  

--- a/target/linux/generic/pending-5.4/770-11-net-ethernet-mtk_eth_soc-avoid-rearming-interrupt-if.patch
+++ b/target/linux/generic/pending-5.4/770-11-net-ethernet-mtk_eth_soc-avoid-rearming-interrupt-if.patch
@@ -10,7 +10,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 
 --- a/drivers/net/ethernet/mediatek/mtk_eth_soc.c
 +++ b/drivers/net/ethernet/mediatek/mtk_eth_soc.c
-@@ -1515,8 +1515,8 @@ static int mtk_napi_tx(struct napi_struc
+@@ -1536,8 +1536,8 @@ static int mtk_napi_tx(struct napi_struc
  	if (status & MTK_TX_DONE_INT)
  		return budget;
  
@@ -21,7 +21,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  
  	return tx_done;
  }
-@@ -1549,8 +1549,9 @@ poll_again:
+@@ -1570,8 +1570,9 @@ poll_again:
  		remain_budget -= rx_done;
  		goto poll_again;
  	}

--- a/target/linux/generic/pending-5.4/770-13-net-ethernet-mtk_eth_soc-fix-parsing-packets-in-GDM.patch
+++ b/target/linux/generic/pending-5.4/770-13-net-ethernet-mtk_eth_soc-fix-parsing-packets-in-GDM.patch
@@ -18,7 +18,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  
  #include "mtk_eth_soc.h"
  
-@@ -1259,13 +1260,12 @@ static int mtk_poll_rx(struct napi_struc
+@@ -1280,13 +1281,12 @@ static int mtk_poll_rx(struct napi_struc
  			break;
  
  		/* find out which mac the packet come from. values start at 1 */
@@ -37,7 +37,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  
  		if (unlikely(mac < 0 || mac >= MTK_MAC_COUNT ||
  			     !eth->netdev[mac]))
-@@ -2247,6 +2247,9 @@ static void mtk_gdm_config(struct mtk_et
+@@ -2268,6 +2268,9 @@ static void mtk_gdm_config(struct mtk_et
  
  		val |= config;
  
@@ -57,7 +57,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  #define MTK_GDMA_ICS_EN		BIT(22)
  #define MTK_GDMA_TCS_EN		BIT(21)
  #define MTK_GDMA_UCS_EN		BIT(20)
-@@ -311,6 +312,7 @@
+@@ -324,6 +325,7 @@
  #define RX_DMA_L4_VALID_PDMA	BIT(30)		/* when PDMA is used */
  #define RX_DMA_FPORT_SHIFT	19
  #define RX_DMA_FPORT_MASK	0x7

--- a/target/linux/generic/pending-5.4/770-14-net-ethernet-mtk_eth_soc-set-PPE-flow-hash-as-skb-ha.patch
+++ b/target/linux/generic/pending-5.4/770-14-net-ethernet-mtk_eth_soc-set-PPE-flow-hash-as-skb-ha.patch
@@ -18,7 +18,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  #include <net/dsa.h>
  
  #include "mtk_eth_soc.h"
-@@ -1246,6 +1247,7 @@ static int mtk_poll_rx(struct napi_struc
+@@ -1267,6 +1268,7 @@ static int mtk_poll_rx(struct napi_struc
  		struct net_device *netdev;
  		unsigned int pktlen;
  		dma_addr_t dma_addr;
@@ -26,7 +26,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  		int mac;
  
  		ring = mtk_get_rx_ring(eth);
-@@ -1315,6 +1317,12 @@ static int mtk_poll_rx(struct napi_struc
+@@ -1336,6 +1338,12 @@ static int mtk_poll_rx(struct napi_struc
  		skb->protocol = eth_type_trans(skb, netdev);
  		bytes += pktlen;
  

--- a/target/linux/generic/pending-5.4/770-15-net-ethernet-mediatek-mtk_eth_soc-add-support-for-in.patch
+++ b/target/linux/generic/pending-5.4/770-15-net-ethernet-mediatek-mtk_eth_soc-add-support-for-in.patch
@@ -24,7 +24,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 +mtk_eth-y := mtk_eth_soc.o mtk_sgmii.o mtk_eth_path.o mtk_ppe.o
 --- a/drivers/net/ethernet/mediatek/mtk_eth_soc.c
 +++ b/drivers/net/ethernet/mediatek/mtk_eth_soc.c
-@@ -2280,12 +2280,17 @@ static int mtk_open(struct net_device *d
+@@ -2301,12 +2301,17 @@ static int mtk_open(struct net_device *d
  
  	/* we run 2 netdevs on the same dma ring so we only bring it up once */
  	if (!refcount_read(&eth->dma_refcnt)) {
@@ -44,7 +44,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  
  		napi_enable(&eth->tx_napi);
  		napi_enable(&eth->rx_napi);
-@@ -2355,6 +2360,9 @@ static int mtk_stop(struct net_device *d
+@@ -2376,6 +2381,9 @@ static int mtk_stop(struct net_device *d
  
  	mtk_dma_free(eth);
  
@@ -54,7 +54,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	return 0;
  }
  
-@@ -3144,6 +3152,13 @@ static int mtk_probe(struct platform_dev
+@@ -3165,6 +3173,13 @@ static int mtk_probe(struct platform_dev
  			goto err_free_dev;
  	}
  
@@ -68,7 +68,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	for (i = 0; i < MTK_MAX_DEVS; i++) {
  		if (!eth->netdev[i])
  			continue;
-@@ -3218,6 +3233,7 @@ static const struct mtk_soc_data mt7621_
+@@ -3239,6 +3254,7 @@ static const struct mtk_soc_data mt7621_
  	.hw_features = MTK_HW_FEATURES,
  	.required_clks = MT7621_CLKS_BITMAP,
  	.required_pctl = false,
@@ -76,7 +76,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  };
  
  static const struct mtk_soc_data mt7622_data = {
-@@ -3226,6 +3242,7 @@ static const struct mtk_soc_data mt7622_
+@@ -3247,6 +3263,7 @@ static const struct mtk_soc_data mt7622_
  	.hw_features = MTK_HW_FEATURES,
  	.required_clks = MT7622_CLKS_BITMAP,
  	.required_pctl = false,
@@ -102,7 +102,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  #define MTK_GDMA_DROP_ALL       0x7777
  
  /* Unicast Filter MAC Address Register - Low */
-@@ -308,6 +310,12 @@
+@@ -321,6 +323,12 @@
  #define RX_DMA_VID(_x)		((_x) & 0xfff)
  
  /* QDMA descriptor rxd4 */
@@ -115,7 +115,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  #define RX_DMA_L4_VALID		BIT(24)
  #define RX_DMA_L4_VALID_PDMA	BIT(30)		/* when PDMA is used */
  #define RX_DMA_FPORT_SHIFT	19
-@@ -807,6 +815,7 @@ struct mtk_soc_data {
+@@ -827,6 +835,7 @@ struct mtk_soc_data {
  	u32		caps;
  	u32		required_clks;
  	bool		required_pctl;
@@ -123,7 +123,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	netdev_features_t hw_features;
  };
  
-@@ -918,6 +927,8 @@ struct mtk_eth {
+@@ -938,6 +947,8 @@ struct mtk_eth {
  	u32				tx_int_status_reg;
  	u32				rx_dma_l4_valid;
  	int				ip_align;

--- a/target/linux/generic/pending-5.4/770-16-net-ethernet-mediatek-mtk_eth_soc-add-flow-offloadin.patch
+++ b/target/linux/generic/pending-5.4/770-16-net-ethernet-mediatek-mtk_eth_soc-add-flow-offloadin.patch
@@ -29,7 +29,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  #include <net/dsa.h>
  
  #include "mtk_eth_soc.h"
-@@ -1327,8 +1329,12 @@ static int mtk_poll_rx(struct napi_struc
+@@ -1348,8 +1350,12 @@ static int mtk_poll_rx(struct napi_struc
  		    (trxd.rxd2 & RX_DMA_VTAG))
  			__vlan_hwaccel_put_tag(skb, htons(ETH_P_8021Q),
  					       RX_DMA_VID(trxd.rxd3));
@@ -44,7 +44,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  
  skip_rx:
  		ring->data[idx] = new_data;
-@@ -2861,6 +2867,25 @@ static int mtk_set_rxnfc(struct net_devi
+@@ -2882,6 +2888,25 @@ static int mtk_set_rxnfc(struct net_devi
  	return ret;
  }
  
@@ -70,7 +70,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  static const struct ethtool_ops mtk_ethtool_ops = {
  	.get_link_ksettings	= mtk_get_link_ksettings,
  	.set_link_ksettings	= mtk_set_link_ksettings,
-@@ -2892,6 +2917,7 @@ static const struct net_device_ops mtk_n
+@@ -2913,6 +2938,7 @@ static const struct net_device_ops mtk_n
  #ifdef CONFIG_NET_POLL_CONTROLLER
  	.ndo_poll_controller	= mtk_poll_controller,
  #endif
@@ -78,7 +78,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  };
  
  static int mtk_add_mac(struct mtk_eth *eth, struct device_node *np)
-@@ -3157,6 +3183,10 @@ static int mtk_probe(struct platform_dev
+@@ -3178,6 +3204,10 @@ static int mtk_probe(struct platform_dev
  				   eth->base + MTK_ETH_PPE_BASE, 2);
  		if (err)
  			goto err_free_dev;
@@ -91,7 +91,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	for (i = 0; i < MTK_MAX_DEVS; i++) {
 --- a/drivers/net/ethernet/mediatek/mtk_eth_soc.h
 +++ b/drivers/net/ethernet/mediatek/mtk_eth_soc.h
-@@ -929,6 +929,7 @@ struct mtk_eth {
+@@ -949,6 +949,7 @@ struct mtk_eth {
  	int				ip_align;
  
  	struct mtk_ppe			ppe;
@@ -99,7 +99,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  };
  
  /* struct mtk_mac -	the structure that holds the info about the MACs of the
-@@ -973,4 +974,12 @@ int mtk_gmac_sgmii_path_setup(struct mtk
+@@ -993,4 +994,12 @@ int mtk_gmac_sgmii_path_setup(struct mtk
  int mtk_gmac_gephy_path_setup(struct mtk_eth *eth, int mac_id);
  int mtk_gmac_rgmii_path_setup(struct mtk_eth *eth, int mac_id);
  

--- a/target/linux/layerscape/patches-5.4/701-net-0029-sdk_dpaa-update-the-xmit-timestamp-to-avoid-watchdog.patch
+++ b/target/linux/layerscape/patches-5.4/701-net-0029-sdk_dpaa-update-the-xmit-timestamp-to-avoid-watchdog.patch
@@ -59,7 +59,7 @@ Signed-off-by: Camelia Groza <camelia.groza@nxp.com>
   */
 --- a/net/sched/sch_generic.c
 +++ b/net/sched/sch_generic.c
-@@ -440,6 +440,13 @@ static void dev_watchdog(struct timer_li
+@@ -465,6 +465,13 @@ static void dev_watchdog(struct timer_li
  					txq->trans_timeout++;
  					break;
  				}

--- a/target/linux/layerscape/patches-5.4/820-usb-0005-usb-dwc3-add-otg-properties-update.patch
+++ b/target/linux/layerscape/patches-5.4/820-usb-0005-usb-dwc3-add-otg-properties-update.patch
@@ -54,7 +54,7 @@ Signed-off-by: Peter Chen <peter.chen@nxp.com>
  	 * All 3.1 IP version constants are greater than the 3.0 IP
 --- a/drivers/usb/dwc3/gadget.c
 +++ b/drivers/usb/dwc3/gadget.c
-@@ -3574,6 +3574,10 @@ int dwc3_gadget_init(struct dwc3 *dwc)
+@@ -3575,6 +3575,10 @@ int dwc3_gadget_init(struct dwc3 *dwc)
  	dwc->gadget.sg_supported	= true;
  	dwc->gadget.name		= "dwc3-gadget";
  	dwc->gadget.lpm_capable		= true;

--- a/target/linux/mediatek/patches-5.4/0601-net-dsa-propagate-resolved-link-config-via-mac_link_.patch
+++ b/target/linux/mediatek/patches-5.4/0601-net-dsa-propagate-resolved-link-config-via-mac_link_.patch
@@ -64,7 +64,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  
 --- a/drivers/net/dsa/mt7530.c
 +++ b/drivers/net/dsa/mt7530.c
-@@ -1450,7 +1450,9 @@ static void mt7530_phylink_mac_link_down
+@@ -1442,7 +1442,9 @@ static void mt7530_phylink_mac_link_down
  static void mt7530_phylink_mac_link_up(struct dsa_switch *ds, int port,
  				       unsigned int mode,
  				       phy_interface_t interface,
@@ -90,7 +90,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  		mv88e6xxx_mac_link_force(ds, port, LINK_FORCED_UP);
 --- a/drivers/net/dsa/sja1105/sja1105_main.c
 +++ b/drivers/net/dsa/sja1105/sja1105_main.c
-@@ -830,7 +830,9 @@ static void sja1105_mac_link_down(struct
+@@ -831,7 +831,9 @@ static void sja1105_mac_link_down(struct
  static void sja1105_mac_link_up(struct dsa_switch *ds, int port,
  				unsigned int mode,
  				phy_interface_t interface,

--- a/target/linux/mediatek/patches-5.4/0602-net-dsa-mt7530-use-resolved-link-config-in-mac_link_.patch
+++ b/target/linux/mediatek/patches-5.4/0602-net-dsa-mt7530-use-resolved-link-config-in-mac_link_.patch
@@ -51,7 +51,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  
  	mutex_unlock(&priv->reg_mutex);
  }
-@@ -1405,8 +1394,7 @@ static void mt7530_phylink_mac_config(st
+@@ -1397,8 +1386,7 @@ static void mt7530_phylink_mac_config(st
  
  	mcr_cur = mt7530_read(priv, MT7530_PMCR_P(port));
  	mcr_new = mcr_cur;
@@ -61,7 +61,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  	mcr_new |= PMCR_IFG_XMIT(1) | PMCR_MAC_MODE | PMCR_BACKOFF_EN |
  		   PMCR_BACKPR_EN | PMCR_FORCE_MODE;
  
-@@ -1414,26 +1402,6 @@ static void mt7530_phylink_mac_config(st
+@@ -1406,26 +1394,6 @@ static void mt7530_phylink_mac_config(st
  	if (port == 5 && dsa_is_user_port(ds, 5))
  		mcr_new |= PMCR_EXT_PHY;
  
@@ -88,7 +88,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  	if (mcr_new != mcr_cur)
  		mt7530_write(priv, MT7530_PMCR_P(port), mcr_new);
  }
-@@ -1444,7 +1412,7 @@ static void mt7530_phylink_mac_link_down
+@@ -1436,7 +1404,7 @@ static void mt7530_phylink_mac_link_down
  {
  	struct mt7530_priv *priv = ds->priv;
  
@@ -97,7 +97,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  }
  
  static void mt7530_phylink_mac_link_up(struct dsa_switch *ds, int port,
-@@ -1455,8 +1423,31 @@ static void mt7530_phylink_mac_link_up(s
+@@ -1447,8 +1415,31 @@ static void mt7530_phylink_mac_link_up(s
  				       bool tx_pause, bool rx_pause)
  {
  	struct mt7530_priv *priv = ds->priv;

--- a/target/linux/mediatek/patches-5.4/0603-net-dsa-mt7530-Extend-device-data-ready-for-adding-a.patch
+++ b/target/linux/mediatek/patches-5.4/0603-net-dsa-mt7530-Extend-device-data-ready-for-adding-a.patch
@@ -47,7 +47,7 @@ Signed-off-by: Sean Wang <sean.wang@mediatek.com>
  		return -EINVAL;
  	}
  
-@@ -1342,12 +1344,11 @@ mt7530_setup(struct dsa_switch *ds)
+@@ -1334,12 +1336,11 @@ mt7530_setup(struct dsa_switch *ds)
  	return 0;
  }
  
@@ -63,7 +63,7 @@ Signed-off-by: Sean Wang <sean.wang@mediatek.com>
  
  	switch (port) {
  	case 0: /* Internal phy */
-@@ -1356,33 +1357,114 @@ static void mt7530_phylink_mac_config(st
+@@ -1348,33 +1349,114 @@ static void mt7530_phylink_mac_config(st
  	case 3:
  	case 4:
  		if (state->interface != PHY_INTERFACE_MODE_GMII)
@@ -189,7 +189,7 @@ Signed-off-by: Sean Wang <sean.wang@mediatek.com>
  		return;
  	}
  
-@@ -1450,61 +1532,44 @@ static void mt7530_phylink_mac_link_up(s
+@@ -1442,61 +1524,44 @@ static void mt7530_phylink_mac_link_up(s
  	mt7530_set(priv, MT7530_PMCR_P(port), mcr);
  }
  
@@ -274,7 +274,7 @@ Signed-off-by: Sean Wang <sean.wang@mediatek.com>
  	phylink_set(mask, Pause);
  	phylink_set(mask, Asym_Pause);
  
-@@ -1600,12 +1665,45 @@ static int mt7530_set_mac_eee(struct dsa
+@@ -1592,12 +1657,45 @@ static int mt7530_set_mac_eee(struct dsa
  	return 0;
  }
  
@@ -323,7 +323,7 @@ Signed-off-by: Sean Wang <sean.wang@mediatek.com>
  	.get_ethtool_stats	= mt7530_get_ethtool_stats,
  	.get_sset_count		= mt7530_get_sset_count,
  	.port_enable		= mt7530_port_enable,
-@@ -1622,18 +1720,43 @@ static const struct dsa_switch_ops mt753
+@@ -1614,18 +1712,43 @@ static const struct dsa_switch_ops mt753
  	.port_vlan_del		= mt7530_port_vlan_del,
  	.port_mirror_add	= mt7530_port_mirror_add,
  	.port_mirror_del	= mt7530_port_mirror_del,
@@ -372,7 +372,7 @@ Signed-off-by: Sean Wang <sean.wang@mediatek.com>
  	{ /* sentinel */ },
  };
  MODULE_DEVICE_TABLE(of, mt7530_of_match);
-@@ -1671,8 +1794,21 @@ mt7530_probe(struct mdio_device *mdiodev
+@@ -1663,8 +1786,21 @@ mt7530_probe(struct mdio_device *mdiodev
  	/* Get the hardware identifier from the devicetree node.
  	 * We will need it for some of the clock and regulator setup.
  	 */

--- a/target/linux/mediatek/patches-5.4/0604-net-dsa-mt7530-Add-the-support-of-MT7531-switch.patch
+++ b/target/linux/mediatek/patches-5.4/0604-net-dsa-mt7530-Add-the-support-of-MT7531-switch.patch
@@ -394,7 +394,7 @@ Signed-off-by: Sean Wang <sean.wang@mediatek.com>
  	 */
  	mt7530_write(priv, MT7530_PCR_P(port),
  		     PCR_MATRIX(dsa_user_ports(priv->ds)));
-@@ -1130,27 +1454,42 @@ mt7530_port_vlan_del(struct dsa_switch *
+@@ -1122,27 +1446,42 @@ mt7530_port_vlan_del(struct dsa_switch *
  	return 0;
  }
  
@@ -444,7 +444,7 @@ Signed-off-by: Sean Wang <sean.wang@mediatek.com>
  
  	val = mt7530_read(priv, MT7530_PCR_P(port));
  	if (ingress) {
-@@ -1165,7 +1504,7 @@ static int mt7530_port_mirror_add(struct
+@@ -1157,7 +1496,7 @@ static int mt7530_port_mirror_add(struct
  	return 0;
  }
  
@@ -453,7 +453,7 @@ Signed-off-by: Sean Wang <sean.wang@mediatek.com>
  				   struct dsa_mall_mirror_tc_entry *mirror)
  {
  	struct mt7530_priv *priv = ds->priv;
-@@ -1182,9 +1521,9 @@ static void mt7530_port_mirror_del(struc
+@@ -1174,9 +1513,9 @@ static void mt7530_port_mirror_del(struc
  	mt7530_write(priv, MT7530_PCR_P(port), val);
  
  	if (!priv->mirror_rx && !priv->mirror_tx) {
@@ -466,7 +466,7 @@ Signed-off-by: Sean Wang <sean.wang@mediatek.com>
  	}
  }
  
-@@ -1290,7 +1629,7 @@ mt7530_setup(struct dsa_switch *ds)
+@@ -1282,7 +1621,7 @@ mt7530_setup(struct dsa_switch *ds)
  			   PCR_MATRIX_CLR);
  
  		if (dsa_is_cpu_port(ds, i))
@@ -475,7 +475,7 @@ Signed-off-by: Sean Wang <sean.wang@mediatek.com>
  		else
  			mt7530_port_disable(ds, i);
  
-@@ -1344,6 +1683,118 @@ mt7530_setup(struct dsa_switch *ds)
+@@ -1336,6 +1675,118 @@ mt7530_setup(struct dsa_switch *ds)
  	return 0;
  }
  
@@ -594,7 +594,7 @@ Signed-off-by: Sean Wang <sean.wang@mediatek.com>
  static bool
  mt7530_phy_mode_supported(struct dsa_switch *ds, int port,
  			  const struct phylink_link_state *state)
-@@ -1382,6 +1833,47 @@ unsupported:
+@@ -1374,6 +1825,47 @@ unsupported:
  	return false;
  }
  
@@ -642,7 +642,7 @@ Signed-off-by: Sean Wang <sean.wang@mediatek.com>
  static bool
  mt753x_phy_mode_supported(struct dsa_switch *ds, int port,
  			  const struct phylink_link_state *state)
-@@ -1414,6 +1906,227 @@ mt7530_mac_config(struct dsa_switch *ds,
+@@ -1406,6 +1898,227 @@ mt7530_mac_config(struct dsa_switch *ds,
  	return 0;
  }
  
@@ -870,7 +870,7 @@ Signed-off-by: Sean Wang <sean.wang@mediatek.com>
  static int
  mt753x_mac_config(struct dsa_switch *ds, int port, unsigned int mode,
  		  const struct phylink_link_state *state)
-@@ -1449,6 +2162,8 @@ mt753x_phylink_mac_config(struct dsa_swi
+@@ -1441,6 +2154,8 @@ mt753x_phylink_mac_config(struct dsa_swi
  		if (mt753x_mac_config(ds, port, mode, state) < 0)
  			goto unsupported;
  
@@ -879,7 +879,7 @@ Signed-off-by: Sean Wang <sean.wang@mediatek.com>
  		break;
  	case 6: /* 1st cpu port */
  		if (priv->p6_interface == state->interface)
-@@ -1468,7 +2183,8 @@ unsupported:
+@@ -1460,7 +2175,8 @@ unsupported:
  		return;
  	}
  
@@ -889,7 +889,7 @@ Signed-off-by: Sean Wang <sean.wang@mediatek.com>
  		dev_err(ds->dev, "%s: in-band negotiation unsupported\n",
  			__func__);
  		return;
-@@ -1478,7 +2194,7 @@ unsupported:
+@@ -1470,7 +2186,7 @@ unsupported:
  	mcr_new = mcr_cur;
  	mcr_new &= ~PMCR_LINK_SETTINGS_MASK;
  	mcr_new |= PMCR_IFG_XMIT(1) | PMCR_MAC_MODE | PMCR_BACKOFF_EN |
@@ -898,7 +898,7 @@ Signed-off-by: Sean Wang <sean.wang@mediatek.com>
  
  	/* Are we connected to external phy */
  	if (port == 5 && dsa_is_user_port(ds, 5))
-@@ -1488,7 +2204,18 @@ unsupported:
+@@ -1480,7 +2196,18 @@ unsupported:
  		mt7530_write(priv, MT7530_PMCR_P(port), mcr_new);
  }
  
@@ -918,7 +918,7 @@ Signed-off-by: Sean Wang <sean.wang@mediatek.com>
  					 unsigned int mode,
  					 phy_interface_t interface)
  {
-@@ -1497,7 +2224,19 @@ static void mt7530_phylink_mac_link_down
+@@ -1489,7 +2216,19 @@ static void mt7530_phylink_mac_link_down
  	mt7530_clear(priv, MT7530_PMCR_P(port), PMCR_LINK_SETTINGS_MASK);
  }
  
@@ -939,7 +939,7 @@ Signed-off-by: Sean Wang <sean.wang@mediatek.com>
  				       unsigned int mode,
  				       phy_interface_t interface,
  				       struct phy_device *phydev,
-@@ -1507,18 +2246,29 @@ static void mt7530_phylink_mac_link_up(s
+@@ -1499,18 +2238,29 @@ static void mt7530_phylink_mac_link_up(s
  	struct mt7530_priv *priv = ds->priv;
  	u32 mcr;
  
@@ -971,7 +971,7 @@ Signed-off-by: Sean Wang <sean.wang@mediatek.com>
  		break;
  	}
  	if (duplex == DUPLEX_FULL) {
-@@ -1532,6 +2282,45 @@ static void mt7530_phylink_mac_link_up(s
+@@ -1524,6 +2274,45 @@ static void mt7530_phylink_mac_link_up(s
  	mt7530_set(priv, MT7530_PMCR_P(port), mcr);
  }
  
@@ -1017,7 +1017,7 @@ Signed-off-by: Sean Wang <sean.wang@mediatek.com>
  static void
  mt7530_mac_port_validate(struct dsa_switch *ds, int port,
  			 unsigned long *supported)
-@@ -1540,6 +2329,14 @@ mt7530_mac_port_validate(struct dsa_swit
+@@ -1532,6 +2321,14 @@ mt7530_mac_port_validate(struct dsa_swit
  		phylink_set(supported, 1000baseX_Full);
  }
  
@@ -1032,7 +1032,7 @@ Signed-off-by: Sean Wang <sean.wang@mediatek.com>
  static void
  mt753x_phylink_validate(struct dsa_switch *ds, int port,
  			unsigned long *supported,
-@@ -1556,7 +2353,8 @@ mt753x_phylink_validate(struct dsa_switc
+@@ -1548,7 +2345,8 @@ mt753x_phylink_validate(struct dsa_switc
  
  	phylink_set_port_modes(mask);
  
@@ -1042,7 +1042,7 @@ Signed-off-by: Sean Wang <sean.wang@mediatek.com>
  		phylink_set(mask, 10baseT_Half);
  		phylink_set(mask, 10baseT_Full);
  		phylink_set(mask, 100baseT_Half);
-@@ -1575,6 +2373,11 @@ mt753x_phylink_validate(struct dsa_switc
+@@ -1567,6 +2365,11 @@ mt753x_phylink_validate(struct dsa_switc
  
  	linkmode_and(supported, supported, mask);
  	linkmode_and(state->advertising, state->advertising, mask);
@@ -1054,7 +1054,7 @@ Signed-off-by: Sean Wang <sean.wang@mediatek.com>
  }
  
  static int
-@@ -1665,6 +2468,63 @@ static int mt7530_set_mac_eee(struct dsa
+@@ -1657,6 +2460,63 @@ static int mt7530_set_mac_eee(struct dsa
  	return 0;
  }
  
@@ -1118,7 +1118,7 @@ Signed-off-by: Sean Wang <sean.wang@mediatek.com>
  static int
  mt753x_phylink_mac_link_state(struct dsa_switch *ds, int port,
  			      struct phylink_link_state *state)
-@@ -1718,13 +2578,14 @@ static const struct dsa_switch_ops mt753
+@@ -1710,13 +2570,14 @@ static const struct dsa_switch_ops mt753
  	.port_vlan_prepare	= mt7530_port_vlan_prepare,
  	.port_vlan_add		= mt7530_port_vlan_add,
  	.port_vlan_del		= mt7530_port_vlan_del,
@@ -1137,7 +1137,7 @@ Signed-off-by: Sean Wang <sean.wang@mediatek.com>
  	.get_mac_eee		= mt7530_get_mac_eee,
  	.set_mac_eee		= mt7530_set_mac_eee,
  };
-@@ -1752,11 +2613,26 @@ static const struct mt753x_info mt753x_t
+@@ -1744,11 +2605,26 @@ static const struct mt753x_info mt753x_t
  		.mac_port_get_state = mt7530_phylink_mac_link_state,
  		.mac_port_config = mt7530_mac_config,
  	},

--- a/target/linux/mediatek/patches-5.4/1011-net-ethernet-mtk_eth_soc-add-support-for-coherent-DM.patch
+++ b/target/linux/mediatek/patches-5.4/1011-net-ethernet-mtk_eth_soc-add-support-for-coherent-DM.patch
@@ -37,7 +37,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  #include <linux/mfd/syscon.h>
  #include <linux/regmap.h>
  #include <linux/clk.h>
-@@ -2485,6 +2486,13 @@ static int mtk_hw_init(struct mtk_eth *e
+@@ -2506,6 +2507,13 @@ static int mtk_hw_init(struct mtk_eth *e
  	if (ret)
  		goto err_disable_pm;
  
@@ -51,7 +51,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	if (MTK_HAS_CAPS(eth->soc->caps, MTK_SOC_MT7628)) {
  		ret = device_reset(eth->dev);
  		if (ret) {
-@@ -3083,6 +3091,16 @@ static int mtk_probe(struct platform_dev
+@@ -3104,6 +3112,16 @@ static int mtk_probe(struct platform_dev
  		}
  	}
  
@@ -70,7 +70,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  					  GFP_KERNEL);
 --- a/drivers/net/ethernet/mediatek/mtk_eth_soc.h
 +++ b/drivers/net/ethernet/mediatek/mtk_eth_soc.h
-@@ -435,6 +435,12 @@
+@@ -448,6 +448,12 @@
  #define RSTCTRL_FE		BIT(6)
  #define RSTCTRL_PPE		BIT(31)
  

--- a/target/linux/ramips/patches-5.4/0007-MIPS-ralink-copy-the-commandline-from-the-devicetree.patch
+++ b/target/linux/ramips/patches-5.4/0007-MIPS-ralink-copy-the-commandline-from-the-devicetree.patch
@@ -10,7 +10,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 
 --- a/arch/mips/ralink/of.c
 +++ b/arch/mips/ralink/of.c
-@@ -80,6 +80,8 @@ void __init plat_mem_setup(void)
+@@ -82,6 +82,8 @@ void __init plat_mem_setup(void)
  
  	__dt_setup_arch(dtb);
  

--- a/target/linux/ramips/patches-5.4/0048-asoc-add-mt7620-support.patch
+++ b/target/linux/ramips/patches-5.4/0048-asoc-add-mt7620-support.patch
@@ -18,24 +18,6 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  create mode 100644 sound/soc/ralink/mt7620-i2s.c
  create mode 100644 sound/soc/ralink/mt7620-wm8960.c
 
---- a/arch/mips/ralink/of.c
-+++ b/arch/mips/ralink/of.c
-@@ -13,6 +13,7 @@
- #include <linux/of_fdt.h>
- #include <linux/kernel.h>
- #include <linux/memblock.h>
-+#include <linux/module.h>
- #include <linux/of_platform.h>
- #include <linux/of_address.h>
- 
-@@ -24,6 +25,7 @@
- #include "common.h"
- 
- __iomem void *rt_sysc_membase;
-+EXPORT_SYMBOL(rt_sysc_membase);
- __iomem void *rt_memc_membase;
- 
- __iomem void *plat_of_remap_node(const char *node)
 --- a/sound/soc/Kconfig
 +++ b/sound/soc/Kconfig
 @@ -60,6 +60,7 @@ source "sound/soc/mxs/Kconfig"

--- a/target/linux/ramips/patches-5.4/401-net-ethernet-mediatek-support-net-labels.patch
+++ b/target/linux/ramips/patches-5.4/401-net-ethernet-mediatek-support-net-labels.patch
@@ -14,7 +14,7 @@ Signed-off-by: René van Dorst <opensource@vdorst.com>
 
 --- a/drivers/net/ethernet/mediatek/mtk_eth_soc.c
 +++ b/drivers/net/ethernet/mediatek/mtk_eth_soc.c
-@@ -2922,6 +2922,7 @@ static const struct net_device_ops mtk_n
+@@ -2943,6 +2943,7 @@ static const struct net_device_ops mtk_n
  
  static int mtk_add_mac(struct mtk_eth *eth, struct device_node *np)
  {
@@ -22,7 +22,7 @@ Signed-off-by: René van Dorst <opensource@vdorst.com>
  	const __be32 *_id = of_get_property(np, "reg", NULL);
  	struct phylink *phylink;
  	int phy_mode, id, err;
-@@ -3014,6 +3015,9 @@ static int mtk_add_mac(struct mtk_eth *e
+@@ -3035,6 +3036,9 @@ static int mtk_add_mac(struct mtk_eth *e
  
  	eth->netdev[id]->max_mtu = MTK_MAX_RX_LENGTH - MTK_RX_ETH_HLEN;
  


### PR DESCRIPTION
Manually rebased:
  generic/hack-5.4/662-remove_pfifo_fast.patch

All other patches automatically rebased.

Build system: x86_64
Build-tested: ipq806x/R7800
Run-tested: ipq806x/R7800

No dmesg regressions, everything functional

Signed-off-by: John Audia <graysky@archlinux.us>
[manual changes to ramips/patches-5.10/835-asoc-add-mt7620-support.patch]
Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [ ] 我知道
