### PR TITLE
kernel: bump 5.4 to 5.4.125

### DIFF
--- a/include/kernel-version.mk
+++ b/include/kernel-version.mk
@@ -8,11 +8,11 @@ endif
 
 LINUX_VERSION-4.14 = .195
 LINUX_VERSION-4.19 = .138
-LINUX_VERSION-5.4 = .124
+LINUX_VERSION-5.4 = .125
 
 LINUX_KERNEL_HASH-4.14.195 = 394f28798670240baacd9e2cce521fbd79f8da5e1fc191695b0e11381445a021
 LINUX_KERNEL_HASH-4.19.138 = d15c27d05f6c527269b75b30cc72972748e55720e7e00ad8abbaa4fe3b1d5e02
-LINUX_KERNEL_HASH-5.4.124 = f7f29dda2b042d7b5986d18274413131cf70e17288c05e9a683df1f46c507d82
+LINUX_KERNEL_HASH-5.4.125 = 17ee750a4aeb1c883d721e730d1f7e2855124585e2f47766864a1359a7ebe33c
 
 remove_uri_prefix=$(subst git://,,$(subst http://,,$(subst https://,,$(1))))
 sanitize_uri=$(call qstrip,$(subst @,_,$(subst :,_,$(subst .,_,$(subst -,_,$(subst /,_,$(1)))))))

--- a/target/linux/ath79/patches-5.4/425-at803x-allow-sgmii-aneg-override.patch
+++ b/target/linux/ath79/patches-5.4/425-at803x-allow-sgmii-aneg-override.patch
@@ -1,6 +1,6 @@
 --- a/drivers/net/phy/at803x.c
 +++ b/drivers/net/phy/at803x.c
-@@ -383,6 +383,13 @@ static int at803x_aneg_done(struct phy_d
+@@ -404,6 +404,13 @@ static int at803x_aneg_done(struct phy_d
  	if (!(phy_read(phydev, AT803X_PSSR) & AT803X_PSSR_MR_AN_COMPLETE)) {
  		phydev_warn(phydev, "803x_aneg_done: SGMII link is not ok\n");
  		aneg_done = 0;

--- a/target/linux/generic/pending-5.4/180-net-phy-at803x-add-support-for-AT8032.patch
+++ b/target/linux/generic/pending-5.4/180-net-phy-at803x-add-support-for-AT8032.patch
@@ -17,9 +17,9 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  #define AT803X_PHY_ID_MASK			0xffffffef
 +#define AT8032_PHY_ID_MASK			0xffffffff
  
- MODULE_DESCRIPTION("Atheros 803x PHY driver");
- MODULE_AUTHOR("Matus Ujhelyi");
-@@ -314,7 +316,7 @@ static int at803x_config_intr(struct phy
+ #define AT803X_PAGE_FIBER		0
+ #define AT803X_PAGE_COPPER		1
+@@ -357,7 +359,7 @@ static int at803x_config_intr(struct phy
  static void at803x_link_change_notify(struct phy_device *phydev)
  {
  	/*
@@ -28,7 +28,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	 * signalled. This is necessary to circumvent a hardware bug that
  	 * occurs when the cable is unplugged while TX packets are pending
  	 * in the FIFO. In such cases, the FIFO enters an error mode it
-@@ -471,6 +473,24 @@ static struct phy_driver at803x_driver[]
+@@ -516,6 +518,24 @@ static struct phy_driver at803x_driver[]
  	.aneg_done		= at803x_aneg_done,
  	.ack_interrupt		= &at803x_ack_interrupt,
  	.config_intr		= &at803x_config_intr,
@@ -53,7 +53,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  } };
  
  module_phy_driver(at803x_driver);
-@@ -478,6 +498,7 @@ module_phy_driver(at803x_driver);
+@@ -523,6 +543,7 @@ module_phy_driver(at803x_driver);
  static struct mdio_device_id __maybe_unused atheros_tbl[] = {
  	{ ATH8030_PHY_ID, AT803X_PHY_ID_MASK },
  	{ ATH8031_PHY_ID, AT803X_PHY_ID_MASK },

--- a/target/linux/generic/pending-5.4/670-ipv6-allow-rejecting-with-source-address-failed-policy.patch
+++ b/target/linux/generic/pending-5.4/670-ipv6-allow-rejecting-with-source-address-failed-policy.patch
@@ -157,7 +157,7 @@ Signed-off-by: Jonas Gorski <jogo@openwrt.org>
  	case RTN_THROW:
  	case RTN_UNREACHABLE:
  	default:
-@@ -4419,6 +4438,17 @@ static int ip6_pkt_prohibit_out(struct n
+@@ -4423,6 +4442,17 @@ static int ip6_pkt_prohibit_out(struct n
  	return ip6_pkt_drop(skb, ICMPV6_ADM_PROHIBITED, IPSTATS_MIB_OUTNOROUTES);
  }
  
@@ -175,7 +175,7 @@ Signed-off-by: Jonas Gorski <jogo@openwrt.org>
  /*
   *	Allocate a dst for local (unicast / anycast) address.
   */
-@@ -4899,7 +4929,8 @@ static int rtm_to_fib6_config(struct sk_
+@@ -4903,7 +4933,8 @@ static int rtm_to_fib6_config(struct sk_
  	if (rtm->rtm_type == RTN_UNREACHABLE ||
  	    rtm->rtm_type == RTN_BLACKHOLE ||
  	    rtm->rtm_type == RTN_PROHIBIT ||
@@ -185,7 +185,7 @@ Signed-off-by: Jonas Gorski <jogo@openwrt.org>
  		cfg->fc_flags |= RTF_REJECT;
  
  	if (rtm->rtm_type == RTN_LOCAL)
-@@ -6021,6 +6052,8 @@ static int ip6_route_dev_notify(struct n
+@@ -6025,6 +6056,8 @@ static int ip6_route_dev_notify(struct n
  #ifdef CONFIG_IPV6_MULTIPLE_TABLES
  		net->ipv6.ip6_prohibit_entry->dst.dev = dev;
  		net->ipv6.ip6_prohibit_entry->rt6i_idev = in6_dev_get(dev);
@@ -194,7 +194,7 @@ Signed-off-by: Jonas Gorski <jogo@openwrt.org>
  		net->ipv6.ip6_blk_hole_entry->dst.dev = dev;
  		net->ipv6.ip6_blk_hole_entry->rt6i_idev = in6_dev_get(dev);
  #endif
-@@ -6032,6 +6065,7 @@ static int ip6_route_dev_notify(struct n
+@@ -6036,6 +6069,7 @@ static int ip6_route_dev_notify(struct n
  		in6_dev_put_clear(&net->ipv6.ip6_null_entry->rt6i_idev);
  #ifdef CONFIG_IPV6_MULTIPLE_TABLES
  		in6_dev_put_clear(&net->ipv6.ip6_prohibit_entry->rt6i_idev);
@@ -202,7 +202,7 @@ Signed-off-by: Jonas Gorski <jogo@openwrt.org>
  		in6_dev_put_clear(&net->ipv6.ip6_blk_hole_entry->rt6i_idev);
  #endif
  	}
-@@ -6224,6 +6258,8 @@ static int __net_init ip6_route_net_init
+@@ -6228,6 +6262,8 @@ static int __net_init ip6_route_net_init
  
  #ifdef CONFIG_IPV6_MULTIPLE_TABLES
  	net->ipv6.fib6_has_custom_rules = false;
@@ -211,7 +211,7 @@ Signed-off-by: Jonas Gorski <jogo@openwrt.org>
  	net->ipv6.ip6_prohibit_entry = kmemdup(&ip6_prohibit_entry_template,
  					       sizeof(*net->ipv6.ip6_prohibit_entry),
  					       GFP_KERNEL);
-@@ -6234,11 +6270,21 @@ static int __net_init ip6_route_net_init
+@@ -6238,11 +6374,21 @@ static int __net_init ip6_route_net_init
  			 ip6_template_metrics, true);
  	INIT_LIST_HEAD(&net->ipv6.ip6_prohibit_entry->rt6i_uncached);
  
@@ -234,7 +234,7 @@ Signed-off-by: Jonas Gorski <jogo@openwrt.org>
  	net->ipv6.ip6_blk_hole_entry->dst.ops = &net->ipv6.ip6_dst_ops;
  	dst_init_metrics(&net->ipv6.ip6_blk_hole_entry->dst,
  			 ip6_template_metrics, true);
-@@ -6262,6 +6308,8 @@ out:
+@@ -6266,6 +6312,8 @@ out:
  	return ret;
  
  #ifdef CONFIG_IPV6_MULTIPLE_TABLES
@@ -243,7 +243,7 @@ Signed-off-by: Jonas Gorski <jogo@openwrt.org>
  out_ip6_prohibit_entry:
  	kfree(net->ipv6.ip6_prohibit_entry);
  out_ip6_null_entry:
-@@ -6281,6 +6329,7 @@ static void __net_exit ip6_route_net_exi
+@@ -6285,6 +6333,7 @@ static void __net_exit ip6_route_net_exi
  	kfree(net->ipv6.ip6_null_entry);
  #ifdef CONFIG_IPV6_MULTIPLE_TABLES
  	kfree(net->ipv6.ip6_prohibit_entry);
@@ -251,7 +251,7 @@ Signed-off-by: Jonas Gorski <jogo@openwrt.org>
  	kfree(net->ipv6.ip6_blk_hole_entry);
  #endif
  	dst_entries_destroy(&net->ipv6.ip6_dst_ops);
-@@ -6358,6 +6407,9 @@ void __init ip6_route_init_special_entri
+@@ -6362,6 +6411,9 @@ void __init ip6_route_init_special_entri
  	init_net.ipv6.ip6_prohibit_entry->rt6i_idev = in6_dev_get(init_net.loopback_dev);
  	init_net.ipv6.ip6_blk_hole_entry->dst.dev = init_net.loopback_dev;
  	init_net.ipv6.ip6_blk_hole_entry->rt6i_idev = in6_dev_get(init_net.loopback_dev);

--- a/target/linux/ramips/patches-5.4/0048-asoc-add-mt7620-support.patch
+++ b/target/linux/ramips/patches-5.4/0048-asoc-add-mt7620-support.patch
@@ -18,6 +18,24 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  create mode 100644 sound/soc/ralink/mt7620-i2s.c
  create mode 100644 sound/soc/ralink/mt7620-wm8960.c
 
+--- a/arch/mips/ralink/of.c
++++ b/arch/mips/ralink/of.c
+@@ -14,6 +14,7 @@
+ #include <linux/of_fdt.h>
+ #include <linux/kernel.h>
+ #include <linux/memblock.h>
++#include <linux/module.h>
+ #include <linux/of_platform.h>
+ #include <linux/of_address.h>
+ 
+@@ -25,6 +26,7 @@
+ #include "common.h"
+ 
+ __iomem void *rt_sysc_membase;
++EXPORT_SYMBOL(rt_sysc_membase);
+ __iomem void *rt_memc_membase;
+ EXPORT_SYMBOL_GPL(rt_sysc_membase);
+ 
 --- a/sound/soc/Kconfig
 +++ b/sound/soc/Kconfig
 @@ -60,6 +60,7 @@ source "sound/soc/mxs/Kconfig"


### PR DESCRIPTION
All patches automatically rebased.

Build system: x86_64
Build-tested: ipq806x/R7800
Run-tested: ipq806x/R7800

No dmesg regressions, everything functional

Signed-off-by: John Audia graysky@archlinux.us

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [ ] 我知道
