### PR TITLE
kernel: bump 5.10 to 5.10.51 (#7437)

### DIFF
--- a/include/kernel-version.mk
+++ b/include/kernel-version.mk
@@ -7,10 +7,10 @@ ifdef CONFIG_TESTING_KERNEL
 endif
 
 LINUX_VERSION-5.4 = .132
-LINUX_VERSION-5.10 = .50
+LINUX_VERSION-5.10 = .51
 
 LINUX_KERNEL_HASH-5.4.132 = 8466adbfb3579e751ede683496df7bb20f258b5f882250f3dd82be63736d00ef
-LINUX_KERNEL_HASH-5.10.50 = 8bda327a7d95acfff8f87fb6ef4223e3194fa22195f5551249a9aa3393bfb436
+LINUX_KERNEL_HASH-5.10.51 = 95bae893c274ccc3a8a6271f377bcc7fd3badcb7990ecd41b05b2731f1d67ae2
 
 remove_uri_prefix=$(subst git://,,$(subst http://,,$(subst https://,,$(1))))
 sanitize_uri=$(call qstrip,$(subst @,_,$(subst :,_,$(subst .,_,$(subst -,_,$(subst /,_,$(1)))))))

--- a/target/linux/ath79/patches-5.10/910-unaligned_access_hacks.patch
+++ b/target/linux/ath79/patches-5.10/910-unaligned_access_hacks.patch
@@ -706,7 +706,7 @@
  EXPORT_SYMBOL(xfrm_parse_spi);
 --- a/net/ipv4/tcp_input.c
 +++ b/net/ipv4/tcp_input.c
-@@ -4074,14 +4074,16 @@ static bool tcp_parse_aligned_timestamp(
+@@ -4081,14 +4081,16 @@ static bool tcp_parse_aligned_timestamp(
  {
  	const __be32 *ptr = (const __be32 *)(th + 1);
  

--- a/target/linux/generic/backport-5.10/103-v5.13-MIPS-select-CPU_MIPS64-for-remaining-MIPS64-CPUs.patch
+++ b/target/linux/generic/backport-5.10/103-v5.13-MIPS-select-CPU_MIPS64-for-remaining-MIPS64-CPUs.patch
@@ -25,7 +25,7 @@ Signed-off-by: Jason A. Donenfeld <Jason@zx2c4.com>
 
 --- a/arch/mips/Kconfig
 +++ b/arch/mips/Kconfig
-@@ -2076,7 +2076,7 @@ config CPU_MIPS32
+@@ -2078,7 +2078,7 @@ config CPU_MIPS32
  config CPU_MIPS64
  	bool
  	default y if CPU_MIPS64_R1 || CPU_MIPS64_R2 || CPU_MIPS64_R5 || \

--- a/target/linux/generic/backport-5.10/600-v5.12-net-extract-napi-poll-functionality-to-__napi_poll.patch
+++ b/target/linux/generic/backport-5.10/600-v5.12-net-extract-napi-poll-functionality-to-__napi_poll.patch
@@ -18,7 +18,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
 
 --- a/net/core/dev.c
 +++ b/net/core/dev.c
-@@ -6772,15 +6772,10 @@ void __netif_napi_del(struct napi_struct
+@@ -6779,15 +6779,10 @@ void __netif_napi_del(struct napi_struct
  }
  EXPORT_SYMBOL(__netif_napi_del);
  
@@ -35,7 +35,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  	weight = n->weight;
  
  	/* This NAPI_STATE_SCHED test is for avoiding a race
-@@ -6800,7 +6795,7 @@ static int napi_poll(struct napi_struct
+@@ -6807,7 +6802,7 @@ static int napi_poll(struct napi_struct
  			    n->poll, work, weight);
  
  	if (likely(work < weight))
@@ -44,7 +44,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  
  	/* Drivers must not modify the NAPI state if they
  	 * consume the entire weight.  In such cases this code
-@@ -6809,7 +6804,7 @@ static int napi_poll(struct napi_struct
+@@ -6816,7 +6811,7 @@ static int napi_poll(struct napi_struct
  	 */
  	if (unlikely(napi_disable_pending(n))) {
  		napi_complete(n);
@@ -53,7 +53,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  	}
  
  	if (n->gro_bitmask) {
-@@ -6827,12 +6822,29 @@ static int napi_poll(struct napi_struct
+@@ -6834,12 +6829,29 @@ static int napi_poll(struct napi_struct
  	if (unlikely(!list_empty(&n->poll_list))) {
  		pr_warn_once("%s: Budget exhausted after napi rescheduled\n",
  			     n->dev ? n->dev->name : "backlog");

--- a/target/linux/generic/backport-5.10/601-v5.12-net-implement-threaded-able-napi-poll-loop-support.patch
+++ b/target/linux/generic/backport-5.10/601-v5.12-net-implement-threaded-able-napi-poll-loop-support.patch
@@ -153,7 +153,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  	list_add_tail(&napi->poll_list, &sd->poll_list);
  	__raise_softirq_irqoff(NET_RX_SOFTIRQ);
  }
-@@ -6725,6 +6762,12 @@ void netif_napi_add(struct net_device *d
+@@ -6732,6 +6769,12 @@ void netif_napi_add(struct net_device *d
  	set_bit(NAPI_STATE_NPSVC, &napi->state);
  	list_add_rcu(&napi->dev_list, &dev->napi_list);
  	napi_hash_add(napi);
@@ -166,7 +166,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  }
  EXPORT_SYMBOL(netif_napi_add);
  
-@@ -6741,9 +6784,28 @@ void napi_disable(struct napi_struct *n)
+@@ -6748,9 +6791,28 @@ void napi_disable(struct napi_struct *n)
  	hrtimer_cancel(&n->timer);
  
  	clear_bit(NAPI_STATE_DISABLE, &n->state);
@@ -195,7 +195,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  static void flush_gro_hash(struct napi_struct *napi)
  {
  	int i;
-@@ -6769,6 +6831,11 @@ void __netif_napi_del(struct napi_struct
+@@ -6776,6 +6838,11 @@ void __netif_napi_del(struct napi_struct
  
  	flush_gro_hash(napi);
  	napi->gro_bitmask = 0;
@@ -207,7 +207,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  }
  EXPORT_SYMBOL(__netif_napi_del);
  
-@@ -6850,6 +6917,51 @@ static int napi_poll(struct napi_struct
+@@ -6857,6 +6924,51 @@ static int napi_poll(struct napi_struct
  	return work;
  }
  

--- a/target/linux/generic/backport-5.10/602-v5.12-net-add-sysfs-attribute-to-control-napi-threaded-mod.patch
+++ b/target/linux/generic/backport-5.10/602-v5.12-net-add-sysfs-attribute-to-control-napi-threaded-mod.patch
@@ -69,7 +69,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  		 * wake_up_process() when it's not NULL.
  		 */
  		thread = READ_ONCE(napi->thread);
-@@ -6735,6 +6736,49 @@ static void init_gro_hash(struct napi_st
+@@ -6742,6 +6743,49 @@ static void init_gro_hash(struct napi_st
  	napi->gro_bitmask = 0;
  }
  

--- a/target/linux/generic/backport-5.10/603-v5.12-net-fix-race-between-napi-kthread-mode-and-busy-poll.patch
+++ b/target/linux/generic/backport-5.10/603-v5.12-net-fix-race-between-napi-kthread-mode-and-busy-poll.patch
@@ -54,7 +54,7 @@ Cc: Hannes Frederic Sowa <hannes@stressinduktion.org>
  			wake_up_process(thread);
  			return;
  		}
-@@ -6527,7 +6529,8 @@ bool napi_complete_done(struct napi_stru
+@@ -6534,7 +6536,8 @@ bool napi_complete_done(struct napi_stru
  
  		WARN_ON_ONCE(!(val & NAPIF_STATE_SCHED));
  
@@ -64,7 +64,7 @@ Cc: Hannes Frederic Sowa <hannes@stressinduktion.org>
  
  		/* If STATE_MISSED was set, leave STATE_SCHED set,
  		 * because we will call napi->poll() one more time.
-@@ -6963,16 +6966,25 @@ static int napi_poll(struct napi_struct
+@@ -6970,16 +6973,25 @@ static int napi_poll(struct napi_struct
  
  static int napi_thread_wait(struct napi_struct *napi)
  {

--- a/target/linux/generic/backport-5.10/604-v5.12-net-fix-hangup-on-napi_disable-for-threaded-napi.patch
+++ b/target/linux/generic/backport-5.10/604-v5.12-net-fix-hangup-on-napi_disable-for-threaded-napi.patch
@@ -34,7 +34,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
 
 --- a/net/core/dev.c
 +++ b/net/core/dev.c
-@@ -6970,7 +6970,7 @@ static int napi_thread_wait(struct napi_
+@@ -6977,7 +6977,7 @@ static int napi_thread_wait(struct napi_
  
  	set_current_state(TASK_INTERRUPTIBLE);
  
@@ -43,7 +43,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  		/* Testing SCHED_THREADED bit here to make sure the current
  		 * kthread owns this napi and could poll on this napi.
  		 * Testing SCHED bit is not enough because SCHED bit might be
-@@ -6988,6 +6988,7 @@ static int napi_thread_wait(struct napi_
+@@ -6995,6 +6995,7 @@ static int napi_thread_wait(struct napi_
  		set_current_state(TASK_INTERRUPTIBLE);
  	}
  	__set_current_state(TASK_RUNNING);

--- a/target/linux/generic/hack-5.10/301-mips_image_cmdline_hack.patch
+++ b/target/linux/generic/hack-5.10/301-mips_image_cmdline_hack.patch
@@ -10,7 +10,7 @@ Signed-off-by: Gabor Juhos <juhosg@openwrt.org>
 
 --- a/arch/mips/Kconfig
 +++ b/arch/mips/Kconfig
-@@ -1163,6 +1163,10 @@ config MIPS_MSC
+@@ -1165,6 +1165,10 @@ config MIPS_MSC
  config SYNC_R4K
  	bool
  

--- a/target/linux/generic/pending-5.10/300-mips_expose_boot_raw.patch
+++ b/target/linux/generic/pending-5.10/300-mips_expose_boot_raw.patch
@@ -9,7 +9,7 @@ Acked-by: Rob Landley <rob@landley.net>
 ---
 --- a/arch/mips/Kconfig
 +++ b/arch/mips/Kconfig
-@@ -1078,9 +1078,6 @@ config FW_ARC
+@@ -1080,9 +1080,6 @@ config FW_ARC
  config ARCH_MAY_HAVE_PC_FDC
  	bool
  
@@ -19,7 +19,7 @@ Acked-by: Rob Landley <rob@landley.net>
  config CEVT_BCM1480
  	bool
  
-@@ -3170,6 +3167,18 @@ choice
+@@ -3172,6 +3169,18 @@ choice
  		bool "Extend builtin kernel arguments with bootloader arguments"
  endchoice
  

--- a/target/linux/generic/pending-5.10/680-NET-skip-GRO-for-foreign-MAC-addresses.patch
+++ b/target/linux/generic/pending-5.10/680-NET-skip-GRO-for-foreign-MAC-addresses.patch
@@ -42,7 +42,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	if (netif_elide_gro(skb->dev))
  		goto normal;
  
-@@ -8006,6 +8009,48 @@ static void __netdev_adjacent_dev_unlink
+@@ -8013,6 +8016,48 @@ static void __netdev_adjacent_dev_unlink
  					   &upper_dev->adj_list.lower);
  }
  
@@ -91,7 +91,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  static int __netdev_upper_dev_link(struct net_device *dev,
  				   struct net_device *upper_dev, bool master,
  				   void *upper_priv, void *upper_info,
-@@ -8057,6 +8102,7 @@ static int __netdev_upper_dev_link(struc
+@@ -8064,6 +8109,7 @@ static int __netdev_upper_dev_link(struc
  	if (ret)
  		return ret;
  
@@ -99,7 +99,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	ret = call_netdevice_notifiers_info(NETDEV_CHANGEUPPER,
  					    &changeupper_info.info);
  	ret = notifier_to_errno(ret);
-@@ -8153,6 +8199,7 @@ static void __netdev_upper_dev_unlink(st
+@@ -8160,6 +8206,7 @@ static void __netdev_upper_dev_unlink(st
  
  	__netdev_adjacent_dev_unlink_neighbour(dev, upper_dev);
  
@@ -107,7 +107,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	call_netdevice_notifiers_info(NETDEV_CHANGEUPPER,
  				      &changeupper_info.info);
  
-@@ -8939,6 +8986,7 @@ int dev_set_mac_address(struct net_devic
+@@ -8946,6 +8993,7 @@ int dev_set_mac_address(struct net_devic
  	if (err)
  		return err;
  	dev->addr_assign_type = NET_ADDR_SET;

--- a/target/linux/generic/pending-5.10/681-NET-add-mtd-mac-address-support-to-of_get_mac_addres.patch
+++ b/target/linux/generic/pending-5.10/681-NET-add-mtd-mac-address-support-to-of_get_mac_addres.patch
@@ -1,5 +1,7 @@
-From: John Crispin <blogic@openwrt.org>
-Subject: NET: add mtd-mac-address support to of_get_mac_address()
+From 6f8e5369ae054ec6c9265581d5a7e39738a5cd84 Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Tue, 30 Mar 2021 13:16:38 +0200
+Subject: [PATCH 1/2] NET: add mtd-mac-address support to of_get_mac_address()
 
 Many embedded devices have information such as mac addresses stored inside mtd
 devices. This patch allows us to add a property inside a node describing a
@@ -8,10 +10,10 @@ where the mac address can be found.
 
 Signed-off-by: John Crispin <blogic@openwrt.org>
 Signed-off-by: Felix Fietkau <nbd@nbd.name>
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
 ---
- drivers/of/of_net.c    |   37 +++++++++++++++++++++++++++++++++++++
- include/linux/of_net.h |    1 +
- 2 files changed, 38 insertions(+)
+ drivers/of/of_net.c | 75 ++++++++++++++++++++++++++++++++++++++++++++-
+ 1 file changed, 74 insertions(+), 1 deletion(-)
 
 --- a/drivers/of/of_net.c
 +++ b/drivers/of/of_net.c
@@ -32,7 +34,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  {
  	struct property *pp = of_find_property(np, name, NULL);
  
-@@ -78,6 +79,79 @@ static const void *of_get_mac_addr_nvmem
+@@ -78,6 +79,70 @@ static const void *of_get_mac_addr_nvmem
  	return mac;
  }
  
@@ -47,10 +49,8 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 +	const char *part;
 +	const __be32 *list;
 +	phandle phandle;
-+	u32 mac_inc = 0;
 +	u8 mac[ETH_ALEN];
 +	void *addr;
-+	u32 inc_idx;
 +
 +	list = of_get_property(np, "mtd-mac-address", &size);
 +	if (!list || (size != (2 * sizeof(*list))))
@@ -73,14 +73,6 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 +
 +	ret = mtd_read(mtd, be32_to_cpup(list), 6, &retlen, mac);
 +	put_mtd_device(mtd);
-+
-+	if (of_property_read_u32(np, "mtd-mac-address-increment-byte", &inc_idx))
-+		inc_idx = 5;
-+	if (inc_idx > 5)
-+		return NULL;
-+
-+	if (!of_property_read_u32(np, "mtd-mac-address-increment", &mac_inc))
-+		mac[inc_idx] += mac_inc;
 +
 +	if (!is_valid_ether_addr(mac))
 +		return NULL;
@@ -109,10 +101,11 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 +	return NULL;
 +}
 +
++
  /**
   * Search the device tree for the best MAC address to use.  'mac-address' is
   * checked first, because that is supposed to contain to "most recent" MAC
-@@ -98,12 +172,20 @@ static const void *of_get_mac_addr_nvmem
+@@ -98,6 +163,10 @@ static const void *of_get_mac_addr_nvmem
   * this case, the real MAC is in 'local-mac-address', and 'mac-address' exists
   * but is all zeros.
   *
@@ -123,13 +116,14 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
   * Return: Will be a valid pointer on success and ERR_PTR in case of error.
  */
  const void *of_get_mac_address(struct device_node *np)
- {
- 	const void *addr;
+@@ -116,6 +185,10 @@ const void *of_get_mac_address(struct de
+ 	if (addr)
+ 		return addr;
  
 +	addr = of_get_mac_address_mtd(np);
 +	if (addr)
 +		return addr;
 +
- 	addr = of_get_mac_addr(np, "mac-address");
- 	if (addr)
- 		return addr;
+ 	return of_get_mac_addr_nvmem(np);
+ }
+ EXPORT_SYMBOL(of_get_mac_address);

--- a/target/linux/generic/pending-5.10/682-of_net-add-mac-address-increment-support.patch
+++ b/target/linux/generic/pending-5.10/682-of_net-add-mac-address-increment-support.patch
@@ -1,0 +1,128 @@
+From 639dba857aa554f2a78572adc4cf3c32de9ec2e2 Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Tue, 30 Mar 2021 18:21:14 +0200
+Subject: [PATCH 2/2] of_net: add mac-address-increment support
+
+Lots of embedded devices use the mac-address of other interface
+extracted from nvmem cells and increments it by one or two. Add two
+bindings to integrate this and directly use the right mac-address for
+the interface. Some example are some routers that use the gmac
+mac-address stored in the art partition and increments it by one for the
+wifi. mac-address-increment-byte bindings is used to tell what byte of
+the mac-address has to be increased (if not defined the last byte is
+increased) and mac-address-increment tells how much the byte decided
+early has to be increased.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+---
+ drivers/of/of_net.c | 59 ++++++++++++++++++++++++++++++++++-----------
+ 1 file changed, 45 insertions(+), 14 deletions(-)
+
+--- a/drivers/of/of_net.c
++++ b/drivers/of/of_net.c
+@@ -55,31 +55,36 @@ static void *of_get_mac_addr(struct devi
+ 	return NULL;
+ }
+ 
+-static const void *of_get_mac_addr_nvmem(struct device_node *np)
++static void *of_get_mac_addr_nvmem(struct device_node *np, int *err)
+ {
+ 	int ret;
+-	const void *mac;
++	void *mac;
+ 	u8 nvmem_mac[ETH_ALEN];
+ 	struct platform_device *pdev = of_find_device_by_node(np);
+ 
+-	if (!pdev)
+-		return ERR_PTR(-ENODEV);
++	if (!pdev) {
++		*err = -ENODEV;
++		return NULL;
++	}
+ 
+ 	ret = nvmem_get_mac_address(&pdev->dev, &nvmem_mac);
+ 	if (ret) {
+ 		put_device(&pdev->dev);
+-		return ERR_PTR(ret);
++		*err = ret;
++		return NULL;
+ 	}
+ 
+ 	mac = devm_kmemdup(&pdev->dev, nvmem_mac, ETH_ALEN, GFP_KERNEL);
+ 	put_device(&pdev->dev);
+-	if (!mac)
+-		return ERR_PTR(-ENOMEM);
++	if (!mac) {
++		*err = -ENOMEM;
++		return NULL;
++	}
+ 
+ 	return mac;
+ }
+ 
+-static const void *of_get_mac_address_mtd(struct device_node *np)
++static void *of_get_mac_address_mtd(struct device_node *np)
+ {
+ #ifdef CONFIG_MTD
+ 	struct device_node *mtd_np = NULL;
+@@ -167,28 +172,54 @@ free:
+  * If a mtd-mac-address property exists, try to fetch the MAC address from the
+  * specified mtd device, and store it as a 'mac-address' property
+  *
++ * DT can tell the system to increment the mac-address after is extracted by
++ * using:
++ * - mac-address-increment-byte to decide what byte to increase
++ *   (if not defined is increased the last byte)
++ * - mac-address-increment to decide how much to increase. The value will
++ *   not overflow to other bytes if the increment is over 255.
++ *   (example 00:01:02:03:04:ff + 1 == 00:01:02:03:04:00)
++ *
+  * Return: Will be a valid pointer on success and ERR_PTR in case of error.
+ */
+ const void *of_get_mac_address(struct device_node *np)
+ {
+-	const void *addr;
++	u32 inc_idx, mac_inc;
++	int ret = 0;
++	u8 *addr;
++
++	/* Check first if the increment byte is present and valid.
++	 * If not set assume to increment the last byte if found.
++	 */
++	if (of_property_read_u32(np, "mac-address-increment-byte", &inc_idx))
++		inc_idx = 5;
++	if (inc_idx < 3 || inc_idx > 5)
++		return ERR_PTR(-EINVAL);
+ 
+ 	addr = of_get_mac_addr(np, "mac-address");
+ 	if (addr)
+-		return addr;
++		goto found;
+ 
+ 	addr = of_get_mac_addr(np, "local-mac-address");
+ 	if (addr)
+-		return addr;
++		goto found;
+ 
+ 	addr = of_get_mac_addr(np, "address");
+ 	if (addr)
+-		return addr;
++		goto found;
+ 
+ 	addr = of_get_mac_address_mtd(np);
+ 	if (addr)
+-		return addr;
++		goto found;
++
++	addr = of_get_mac_addr_nvmem(np, &ret);
++	if (ret)
++		return ERR_PTR(ret);
++
++found:
++	if (!of_property_read_u32(np, "mac-address-increment", &mac_inc))
++		addr[inc_idx] += mac_inc;
+ 
+-	return of_get_mac_addr_nvmem(np);
++	return addr;
+ }
+ EXPORT_SYMBOL(of_get_mac_address);

--- a/target/linux/generic/pending-5.10/810-pci_disable_common_quirks.patch
+++ b/target/linux/generic/pending-5.10/810-pci_disable_common_quirks.patch
@@ -25,7 +25,7 @@ Signed-off-by: Gabor Juhos <juhosg@openwrt.org>
  
 --- a/drivers/pci/quirks.c
 +++ b/drivers/pci/quirks.c
-@@ -205,6 +205,7 @@ static void quirk_mmio_always_on(struct
+@@ -206,6 +206,7 @@ static void quirk_mmio_always_on(struct
  DECLARE_PCI_FIXUP_CLASS_EARLY(PCI_ANY_ID, PCI_ANY_ID,
  				PCI_CLASS_BRIDGE_HOST, 8, quirk_mmio_always_on);
  
@@ -33,7 +33,7 @@ Signed-off-by: Gabor Juhos <juhosg@openwrt.org>
  /*
   * The Mellanox Tavor device gives false positive parity errors.  Mark this
   * device with a broken_parity_status to allow PCI scanning code to "skip"
-@@ -3320,6 +3321,8 @@ DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_I
+@@ -3321,6 +3322,8 @@ DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_I
  DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_INTEL, 0x65f9, quirk_intel_mc_errata);
  DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_INTEL, 0x65fa, quirk_intel_mc_errata);
  
@@ -42,7 +42,7 @@ Signed-off-by: Gabor Juhos <juhosg@openwrt.org>
  /*
   * Ivytown NTB BAR sizes are misreported by the hardware due to an erratum.
   * To work around this, query the size it should be configured to by the
-@@ -3345,6 +3348,8 @@ static void quirk_intel_ntb(struct pci_d
+@@ -3346,6 +3349,8 @@ static void quirk_intel_ntb(struct pci_d
  DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_INTEL, 0x0e08, quirk_intel_ntb);
  DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_INTEL, 0x0e0d, quirk_intel_ntb);
  
@@ -51,7 +51,7 @@ Signed-off-by: Gabor Juhos <juhosg@openwrt.org>
  /*
   * Some BIOS implementations leave the Intel GPU interrupts enabled, even
   * though no one is handling them (e.g., if the i915 driver is never
-@@ -3383,6 +3388,8 @@ DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_IN
+@@ -3384,6 +3389,8 @@ DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_IN
  DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_INTEL, 0x010a, disable_igfx_irq);
  DECLARE_PCI_FIXUP_FINAL(PCI_VENDOR_ID_INTEL, 0x0152, disable_igfx_irq);
  

--- a/target/linux/lantiq/patches-5.10/0152-lantiq-VPE.patch
+++ b/target/linux/lantiq/patches-5.10/0152-lantiq-VPE.patch
@@ -1,6 +1,6 @@
 --- a/arch/mips/Kconfig
 +++ b/arch/mips/Kconfig
-@@ -2426,6 +2426,12 @@ config MIPS_VPE_LOADER
+@@ -2428,6 +2428,12 @@ config MIPS_VPE_LOADER
  	  Includes a loader for loading an elf relocatable object
  	  onto another VPE and running it.
  

--- a/target/linux/ramips/patches-5.10/810-uvc-add-iPassion-iP2970-support.patch
+++ b/target/linux/ramips/patches-5.10/810-uvc-add-iPassion-iP2970-support.patch
@@ -64,7 +64,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  
  #include <media/v4l2-common.h>
  
-@@ -1156,9 +1161,149 @@ static void uvc_video_decode_data(struct
+@@ -1183,9 +1188,149 @@ static void uvc_video_decode_data(struct
  	uvc_urb->async_operations++;
  }
  
@@ -214,7 +214,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  	/* Mark the buffer as done if the EOF marker is set. */
  	if (data[1] & UVC_STREAM_EOF && buf->bytesused != 0) {
  		uvc_trace(UVC_TRACE_FRAME, "Frame complete (EOF found).\n");
-@@ -1715,6 +1860,8 @@ static int uvc_init_video_isoc(struct uv
+@@ -1742,6 +1887,8 @@ static int uvc_init_video_isoc(struct uv
  	if (npackets == 0)
  		return -ENOMEM;
  

--- a/target/linux/rockchip/patches-5.10/101-dts-rockchip-add-usb3-controller-node-for-RK3328-SoCs.patch
+++ b/target/linux/rockchip/patches-5.10/101-dts-rockchip-add-usb3-controller-node-for-RK3328-SoCs.patch
@@ -26,20 +26,30 @@ use-case. You've been warned.
 
 --- a/arch/arm64/boot/dts/rockchip/rk3328.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3328.dtsi
-@@ -984,6 +984,33 @@
- 		status = "disabled";
+@@ -985,22 +985,30 @@
  	};
  
-+	usbdrd3: usb@ff600000 {
+ 	usbdrd3: usb@ff600000 {
+-		compatible = "rockchip,rk3328-dwc3", "snps,dwc3";
+-		reg = <0x0 0xff600000 0x0 0x100000>;
+-		interrupts = <GIC_SPI 67 IRQ_TYPE_LEVEL_HIGH>;
 +		compatible = "rockchip,rk3328-dwc3", "rockchip,rk3399-dwc3";
-+		clocks = <&cru SCLK_USB3OTG_REF>, <&cru SCLK_USB3OTG_SUSPEND>,
-+			 <&cru ACLK_USB3OTG>;
-+		clock-names = "ref_clk", "suspend_clk",
-+			      "bus_clk";
+ 		clocks = <&cru SCLK_USB3OTG_REF>, <&cru SCLK_USB3OTG_SUSPEND>,
+ 			 <&cru ACLK_USB3OTG>;
+ 		clock-names = "ref_clk", "suspend_clk",
+ 			      "bus_clk";
+-		dr_mode = "otg";
+-		phy_type = "utmi_wide";
+-		snps,dis-del-phy-power-chg-quirk;
+-		snps,dis_enblslpm_quirk;
+-		snps,dis-tx-ipgap-linecheck-quirk;
+-		snps,dis-u2-freeclk-exists-quirk;
+-		snps,dis_u2_susphy_quirk;
+-		snps,dis_u3_susphy_quirk;
 +		#address-cells = <2>;
 +		#size-cells = <2>;
 +		ranges;
-+		status = "disabled";
+ 		status = "disabled";
 +
 +		usbdrd_dwc3: dwc3@ff600000 {
 +			compatible = "snps,dwc3";
@@ -55,8 +65,6 @@ use-case. You've been warned.
 +			snps,dis-tx-ipgap-linecheck-quirk;
 +			status = "disabled";
 +		};
-+	};
-+
+ 	};
+ 
  	gic: interrupt-controller@ff811000 {
- 		compatible = "arm,gic-400";
- 		#interrupt-cells = <3>;


### PR DESCRIPTION
* kernel: bump 5.10 to 5.10.51

No deleted or manually refreshed patches.

Signed-off-by: Rui Salvaterra <rsalvaterra@gmail.com>

* linux/rockchip: update the USB 3.0 controller node patch

This has been added in Linux 5.10.51 [1], but it's broken/incomplete. Update our
patch and refresh the remaining patches.

[1] https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=v5.10.51&id=421aff50af5e4cdc56b3ac8d6b670e09697bc8ac

Signed-off-by: Rui Salvaterra <rsalvaterra@gmail.com>

Co-authored-by: Rui Salvaterra <rsalvaterra@gmail.com>

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [ ] 我知道
