### PR TITLE
hostapd: add missing chunk for the snoop interface fix

### DIFF
--- a/package/network/services/hostapd/patches/740-snoop_iface.patch
+++ b/package/network/services/hostapd/patches/740-snoop_iface.patch
@@ -10,17 +10,20 @@
  
 --- a/src/ap/x_snoop.c
 +++ b/src/ap/x_snoop.c
-@@ -71,6 +71,10 @@ x_snoop_get_l2_packet(struct hostapd_dat
+@@ -71,8 +71,12 @@ x_snoop_get_l2_packet(struct hostapd_dat
  {
  	struct hostapd_bss_config *conf = hapd->conf;
  	struct l2_packet_data *l2;
 +	const char *ifname = conf->bridge;
-+
+ 
+-	l2 = l2_packet_init(conf->bridge, NULL, ETH_P_ALL, handler, hapd, 1);
 +	if (conf->snoop_iface[0])
 +		ifname = conf->snoop_iface;
- 
- 	l2 = l2_packet_init(conf->bridge, NULL, ETH_P_ALL, handler, hapd, 1);
++
++	l2 = l2_packet_init(ifname, NULL, ETH_P_ALL, handler, hapd, 1);
  	if (l2 == NULL) {
+ 		wpa_printf(MSG_DEBUG,
+ 			   "x_snoop: Failed to initialize L2 packet processing %s",
 --- a/hostapd/config_file.c
 +++ b/hostapd/config_file.c
 @@ -2357,6 +2357,8 @@ static int hostapd_config_fill(struct ho


### PR DESCRIPTION
Fixes: 7b46377a0cd9 ("hostapd: make the snooping interface (for proxyarp) configurable")
Signed-off-by: Felix Fietkau <nbd@nbd.name>

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [ ] 我知道
