### PR TITLE
base-files: add option to make /var persistent (#7719)

### DIFF
--- a/config/Config-images.in
+++ b/config/Config-images.in
@@ -315,4 +315,12 @@ menu "Target Images"
 		  it will be mounted by PARTUUID which makes the kernel find the
 		  appropriate disk automatically.
 
+	config TARGET_ROOTFS_PERSIST_VAR
+		bool "Make /var persistent"
+		default n
+		help
+		  Do not symlink /var to /tmp, so that its content will persist
+		  across reboots. When enabled, /var/run will still be linked
+		  to /tmp/run.
+
 endmenu

--- a/package/base-files/Makefile
+++ b/package/base-files/Makefile
@@ -173,8 +173,13 @@ define Package/base-files/install
 	mkdir -p $(1)/www
 	mkdir -p $(1)/root
 	$(LN) /proc/mounts $(1)/etc/mtab
+ifneq ($(CONFIG_TARGET_ROOTFS_PERSIST_VAR),y)
 	rm -f $(1)/var
 	$(LN) tmp $(1)/var
+else
+	mkdir -p $(1)/var
+	$(LN) /tmp/run $(1)/var/run
+endif
 	mkdir -p $(1)/etc
 	$(LN) /tmp/resolv.conf /tmp/TZ /tmp/localtime $(1)/etc/
 


### PR DESCRIPTION
* base-files: add option to make /var persistent

In OpenWrt, /var is symlinked to /tmp by default. This is done to reduce
the amount of writes to the flash chip, which often have not the
greatest durability. As a result, things like DHCP or UPnP lease files,
are not persistent across reboots.

Since OpenWrt can run on devices with more durable storage, it makes
sense to have an option for a persistent /var. Add an option to make
/var persistent. When enabled, /var will no longer be symlinked to /tmp,
but /var/run will be symlink to /tmp/run, as it should contains only
files that should not be kept during reboot. The option is off by
default, to maintain the current behaviour.

Signed-off-by: Stijn Tintel <stijn@linux-ipv6.be>

* base-files: fix option to make /var persistent

The option was initially named TARGET_ROOTFS_LN_VAR_TMP, and the check
was correct. When renaming the option to something more suitable, the
check was changed to check for n, but when an option is not set, it's
not n but empty. This results in the check always evaluating to false.
Fix the check by checking for y with ifneq.

Fixes: 57807f50ded6 ("base-files: add option to make /var persistent")

Signed-off-by: Stijn Tintel <stijn@linux-ipv6.be>

Co-authored-by: Stijn Tintel <stijn@linux-ipv6.be>

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [ ] 我知道
