### PR TITLE
kernel: bump 5.10 to 5.10.83

### DIFF
--- a/include/kernel-version.mk
+++ b/include/kernel-version.mk
@@ -7,10 +7,10 @@ ifdef CONFIG_TESTING_KERNEL
 endif
 
 LINUX_VERSION-5.4 = .162
-LINUX_VERSION-5.10 = .82
+LINUX_VERSION-5.10 = .83
 
 LINUX_KERNEL_HASH-5.4.162 = c12d72ddaac78189305a5e98825295ecb02282970033b052276035e83189e25b
-LINUX_KERNEL_HASH-5.10.82 = d66f7c7eed02f84ae550b3c91a26c70eea13682a6d672432f07bce66ff8ce350
+LINUX_KERNEL_HASH-5.10.83 = ef259a43f33ddb56001283f4f4e50af29b8a48fa066aed7371a90ebf38c29b70
 
 remove_uri_prefix=$(subst git://,,$(subst http://,,$(subst https://,,$(1))))
 sanitize_uri=$(call qstrip,$(subst @,_,$(subst :,_,$(subst .,_,$(subst -,_,$(subst /,_,$(1)))))))

--- a/target/linux/bcm27xx/patches-5.10/950-0040-Add-dwc_otg-driver.patch
+++ b/target/linux/bcm27xx/patches-5.10/950-0040-Add-dwc_otg-driver.patch
@@ -1123,7 +1123,7 @@ Signed-off-by: Jonathan Bell <jonathan@raspberrypi.org>
  }
 --- a/drivers/usb/core/hub.c
 +++ b/drivers/usb/core/hub.c
-@@ -5494,7 +5494,7 @@ static void port_event(struct usb_hub *h
+@@ -5503,7 +5503,7 @@ static void port_event(struct usb_hub *h
  		port_dev->over_current_count++;
  		port_over_current_notify(port_dev);
  

--- a/target/linux/bcm27xx/patches-5.10/950-0201-mmc-sdhci-Silence-MMC-warnings.patch
+++ b/target/linux/bcm27xx/patches-5.10/950-0201-mmc-sdhci-Silence-MMC-warnings.patch
@@ -22,7 +22,7 @@ Signed-off-by: Maxime Ripard <maxime@cerno.tech>
  
  #define MAX_TUNING_LOOP 40
  
-@@ -3133,7 +3133,7 @@ static void sdhci_timeout_timer(struct t
+@@ -3145,7 +3145,7 @@ static void sdhci_timeout_timer(struct t
  	spin_lock_irqsave(&host->lock, flags);
  
  	if (host->cmd && !sdhci_data_line_cmd(host->cmd)) {
@@ -31,7 +31,7 @@ Signed-off-by: Maxime Ripard <maxime@cerno.tech>
  		       mmc_hostname(host->mmc));
  		sdhci_dumpregs(host);
  
-@@ -3155,7 +3155,7 @@ static void sdhci_timeout_data_timer(str
+@@ -3167,7 +3167,7 @@ static void sdhci_timeout_data_timer(str
  
  	if (host->data || host->data_cmd ||
  	    (host->cmd && sdhci_data_line_cmd(host->cmd))) {

--- a/target/linux/bcm27xx/patches-5.10/950-0332-staging-fbtft-Add-support-for-display-variants.patch
+++ b/target/linux/bcm27xx/patches-5.10/950-0332-staging-fbtft-Add-support-for-display-variants.patch
@@ -95,7 +95,7 @@ Signed-off-by: Phil Elwell <phil@raspberrypi.com>
  
  #include <video/mipi_display.h>
  
-@@ -1194,6 +1196,7 @@ static struct fbtft_platform_data *fbtft
+@@ -1187,6 +1189,7 @@ static struct fbtft_platform_data *fbtft
   * @display: Display properties
   * @sdev: SPI device
   * @pdev: Platform device
@@ -103,7 +103,7 @@ Signed-off-by: Phil Elwell <phil@raspberrypi.com>
   *
   * Allocates, initializes and registers a framebuffer
   *
-@@ -1203,12 +1206,15 @@ static struct fbtft_platform_data *fbtft
+@@ -1196,12 +1199,15 @@ static struct fbtft_platform_data *fbtft
   */
  int fbtft_probe_common(struct fbtft_display *display,
  		       struct spi_device *sdev,
@@ -120,7 +120,7 @@ Signed-off-by: Phil Elwell <phil@raspberrypi.com>
  	int ret;
  
  	if (sdev)
-@@ -1224,6 +1230,14 @@ int fbtft_probe_common(struct fbtft_disp
+@@ -1217,6 +1223,14 @@ int fbtft_probe_common(struct fbtft_disp
  		pdata = fbtft_properties_read(dev);
  		if (IS_ERR(pdata))
  			return PTR_ERR(pdata);

--- a/target/linux/bcm27xx/patches-5.10/950-0361-ARM-dts-Expand-PCIe-space-on-BCM2711.patch
+++ b/target/linux/bcm27xx/patches-5.10/950-0361-ARM-dts-Expand-PCIe-space-on-BCM2711.patch
@@ -17,7 +17,7 @@ Signed-off-by: Phil Elwell <phil@raspberrypi.com>
 
 --- a/arch/arm/boot/dts/bcm2711.dtsi
 +++ b/arch/arm/boot/dts/bcm2711.dtsi
-@@ -503,8 +503,8 @@
+@@ -509,8 +509,8 @@
  			msi-controller;
  			msi-parent = <&pcie0>;
  

--- a/target/linux/bcm27xx/patches-5.10/950-0388-dt-Use-compatible-string-for-BCM2711-DSI1.patch
+++ b/target/linux/bcm27xx/patches-5.10/950-0388-dt-Use-compatible-string-for-BCM2711-DSI1.patch
@@ -13,7 +13,7 @@ Signed-off-by: Dave Stevenson <dave.stevenson@raspberrypi.com>
 
 --- a/arch/arm/boot/dts/bcm2711.dtsi
 +++ b/arch/arm/boot/dts/bcm2711.dtsi
-@@ -554,6 +554,7 @@
+@@ -560,6 +560,7 @@
  
  &dsi1 {
  	interrupts = <GIC_SPI 108 IRQ_TYPE_LEVEL_HIGH>;

--- a/target/linux/bcm27xx/patches-5.10/950-0697-ARM-dts-bcm2711-fold-in-the-correct-interrupt.patch
+++ b/target/linux/bcm27xx/patches-5.10/950-0697-ARM-dts-bcm2711-fold-in-the-correct-interrupt.patch
@@ -23,7 +23,7 @@ Signed-off-by: Phil Elwell <phil@raspberrypi.com>
  			status = "disabled";
  		};
  
-@@ -1106,7 +1106,3 @@
+@@ -1112,7 +1112,3 @@
  &usb {
  	interrupts = <GIC_SPI 73 IRQ_TYPE_LEVEL_HIGH>;
  };

--- a/target/linux/generic/backport-5.10/610-v5.13-12-net-8021q-resolve-forwarding-path-for-vlan-devices.patch
+++ b/target/linux/generic/backport-5.10/610-v5.13-12-net-8021q-resolve-forwarding-path-for-vlan-devices.patch
@@ -49,7 +49,7 @@ Signed-off-by: Pablo Neira Ayuso <pablo@netfilter.org>
  #define NET_DEVICE_PATH_STACK_MAX	5
 --- a/net/8021q/vlan_dev.c
 +++ b/net/8021q/vlan_dev.c
-@@ -767,6 +767,20 @@ static int vlan_dev_get_iflink(const str
+@@ -770,6 +770,20 @@ static int vlan_dev_get_iflink(const str
  	return real_dev->ifindex;
  }
  
@@ -70,7 +70,7 @@ Signed-off-by: Pablo Neira Ayuso <pablo@netfilter.org>
  static const struct ethtool_ops vlan_ethtool_ops = {
  	.get_link_ksettings	= vlan_ethtool_get_link_ksettings,
  	.get_drvinfo	        = vlan_ethtool_get_drvinfo,
-@@ -805,6 +819,7 @@ static const struct net_device_ops vlan_
+@@ -808,6 +822,7 @@ static const struct net_device_ops vlan_
  #endif
  	.ndo_fix_features	= vlan_dev_fix_features,
  	.ndo_get_iflink		= vlan_dev_get_iflink,

--- a/target/linux/generic/backport-5.10/610-v5.13-14-net-bridge-resolve-forwarding-path-for-VLAN-tag-acti.patch
+++ b/target/linux/generic/backport-5.10/610-v5.13-14-net-bridge-resolve-forwarding-path-for-VLAN-tag-acti.patch
@@ -51,7 +51,7 @@ Signed-off-by: Pablo Neira Ayuso <pablo@netfilter.org>
  enum tc_setup_type {
 --- a/net/8021q/vlan_dev.c
 +++ b/net/8021q/vlan_dev.c
-@@ -777,6 +777,12 @@ static int vlan_dev_fill_forward_path(st
+@@ -780,6 +780,12 @@ static int vlan_dev_fill_forward_path(st
  	path->encap.proto = vlan->vlan_proto;
  	path->dev = ctx->dev;
  	ctx->dev = vlan->real_dev;

--- a/target/linux/generic/hack-5.10/902-debloat_proc.patch
+++ b/target/linux/generic/hack-5.10/902-debloat_proc.patch
@@ -158,7 +158,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  				IPC_SEM_IDS, sysvipc_sem_proc_show);
 --- a/ipc/shm.c
 +++ b/ipc/shm.c
-@@ -144,6 +144,8 @@ pure_initcall(ipc_ns_init);
+@@ -154,6 +154,8 @@ pure_initcall(ipc_ns_init);
  
  void __init shm_init(void)
  {

--- a/target/linux/generic/pending-5.10/670-ipv6-allow-rejecting-with-source-address-failed-policy.patch
+++ b/target/linux/generic/pending-5.10/670-ipv6-allow-rejecting-with-source-address-failed-policy.patch
@@ -157,7 +157,7 @@ Signed-off-by: Jonas Gorski <jogo@openwrt.org>
  	case RTN_THROW:
  	case RTN_UNREACHABLE:
  	default:
-@@ -4429,6 +4448,17 @@ static int ip6_pkt_prohibit_out(struct n
+@@ -4448,6 +4467,17 @@ static int ip6_pkt_prohibit_out(struct n
  	return ip6_pkt_drop(skb, ICMPV6_ADM_PROHIBITED, IPSTATS_MIB_OUTNOROUTES);
  }
  
@@ -175,7 +175,7 @@ Signed-off-by: Jonas Gorski <jogo@openwrt.org>
  /*
   *	Allocate a dst for local (unicast / anycast) address.
   */
-@@ -4909,7 +4939,8 @@ static int rtm_to_fib6_config(struct sk_
+@@ -4928,7 +4958,8 @@ static int rtm_to_fib6_config(struct sk_
  	if (rtm->rtm_type == RTN_UNREACHABLE ||
  	    rtm->rtm_type == RTN_BLACKHOLE ||
  	    rtm->rtm_type == RTN_PROHIBIT ||
@@ -185,7 +185,7 @@ Signed-off-by: Jonas Gorski <jogo@openwrt.org>
  		cfg->fc_flags |= RTF_REJECT;
  
  	if (rtm->rtm_type == RTN_LOCAL)
-@@ -6080,6 +6111,8 @@ static int ip6_route_dev_notify(struct n
+@@ -6099,6 +6130,8 @@ static int ip6_route_dev_notify(struct n
  #ifdef CONFIG_IPV6_MULTIPLE_TABLES
  		net->ipv6.ip6_prohibit_entry->dst.dev = dev;
  		net->ipv6.ip6_prohibit_entry->rt6i_idev = in6_dev_get(dev);
@@ -194,7 +194,7 @@ Signed-off-by: Jonas Gorski <jogo@openwrt.org>
  		net->ipv6.ip6_blk_hole_entry->dst.dev = dev;
  		net->ipv6.ip6_blk_hole_entry->rt6i_idev = in6_dev_get(dev);
  #endif
-@@ -6091,6 +6124,7 @@ static int ip6_route_dev_notify(struct n
+@@ -6110,6 +6143,7 @@ static int ip6_route_dev_notify(struct n
  		in6_dev_put_clear(&net->ipv6.ip6_null_entry->rt6i_idev);
  #ifdef CONFIG_IPV6_MULTIPLE_TABLES
  		in6_dev_put_clear(&net->ipv6.ip6_prohibit_entry->rt6i_idev);
@@ -202,7 +202,7 @@ Signed-off-by: Jonas Gorski <jogo@openwrt.org>
  		in6_dev_put_clear(&net->ipv6.ip6_blk_hole_entry->rt6i_idev);
  #endif
  	}
-@@ -6282,6 +6316,8 @@ static int __net_init ip6_route_net_init
+@@ -6301,6 +6335,8 @@ static int __net_init ip6_route_net_init
  
  #ifdef CONFIG_IPV6_MULTIPLE_TABLES
  	net->ipv6.fib6_has_custom_rules = false;
@@ -211,7 +211,7 @@ Signed-off-by: Jonas Gorski <jogo@openwrt.org>
  	net->ipv6.ip6_prohibit_entry = kmemdup(&ip6_prohibit_entry_template,
  					       sizeof(*net->ipv6.ip6_prohibit_entry),
  					       GFP_KERNEL);
-@@ -6292,11 +6328,21 @@ static int __net_init ip6_route_net_init
+@@ -6311,11 +6347,21 @@ static int __net_init ip6_route_net_init
  			 ip6_template_metrics, true);
  	INIT_LIST_HEAD(&net->ipv6.ip6_prohibit_entry->rt6i_uncached);
  
@@ -234,7 +234,7 @@ Signed-off-by: Jonas Gorski <jogo@openwrt.org>
  	net->ipv6.ip6_blk_hole_entry->dst.ops = &net->ipv6.ip6_dst_ops;
  	dst_init_metrics(&net->ipv6.ip6_blk_hole_entry->dst,
  			 ip6_template_metrics, true);
-@@ -6323,6 +6369,8 @@ out:
+@@ -6342,6 +6388,8 @@ out:
  	return ret;
  
  #ifdef CONFIG_IPV6_MULTIPLE_TABLES
@@ -243,7 +243,7 @@ Signed-off-by: Jonas Gorski <jogo@openwrt.org>
  out_ip6_prohibit_entry:
  	kfree(net->ipv6.ip6_prohibit_entry);
  out_ip6_null_entry:
-@@ -6342,6 +6390,7 @@ static void __net_exit ip6_route_net_exi
+@@ -6361,6 +6409,7 @@ static void __net_exit ip6_route_net_exi
  	kfree(net->ipv6.ip6_null_entry);
  #ifdef CONFIG_IPV6_MULTIPLE_TABLES
  	kfree(net->ipv6.ip6_prohibit_entry);
@@ -251,7 +251,7 @@ Signed-off-by: Jonas Gorski <jogo@openwrt.org>
  	kfree(net->ipv6.ip6_blk_hole_entry);
  #endif
  	dst_entries_destroy(&net->ipv6.ip6_dst_ops);
-@@ -6419,6 +6468,9 @@ void __init ip6_route_init_special_entri
+@@ -6438,6 +6487,9 @@ void __init ip6_route_init_special_entri
  	init_net.ipv6.ip6_prohibit_entry->rt6i_idev = in6_dev_get(init_net.loopback_dev);
  	init_net.ipv6.ip6_blk_hole_entry->dst.dev = init_net.loopback_dev;
  	init_net.ipv6.ip6_blk_hole_entry->rt6i_idev = in6_dev_get(init_net.loopback_dev);

--- a/target/linux/ipq806x/patches-5.10/083-ipq8064-dtsi-additions.patch
+++ b/target/linux/ipq806x/patches-5.10/083-ipq8064-dtsi-additions.patch
@@ -78,9 +78,9 @@
 +			opp-microvolt = <1150000>;
 +			clock-latency-ns = <100000>;
 +			opp-level = <2>;
- 		};
- 	};
- 
++		};
++	};
++
 +	opp_table0: opp_table0 {
 +		compatible = "operating-points-v2-kryo-cpu";
 +		nvmem-cells = <&speedbin_efuse>;
@@ -149,9 +149,9 @@
 +			opp-supported-hw = <0x1>;
 +			clock-latency-ns = <100000>;
 +			opp-level = <2>;
-+		};
-+	};
-+
+ 		};
+ 	};
+ 
 +	thermal-zones {
 +		tsens_tz_sensor0 {
 +			polling-delay-passive = <0>;

--- a/target/linux/ramips/patches-5.10/720-Revert-net-phy-simplify-phy_link_change-arguments.patch
+++ b/target/linux/ramips/patches-5.10/720-Revert-net-phy-simplify-phy_link_change-arguments.patch
@@ -95,7 +95,7 @@ still required by target/linux/ramips/files/drivers/net/ethernet/ralink/mdio.c
  		phydev->mii_ts->link_state(phydev->mii_ts, phydev);
 --- a/drivers/net/phy/phylink.c
 +++ b/drivers/net/phy/phylink.c
-@@ -907,7 +907,8 @@ void phylink_destroy(struct phylink *pl)
+@@ -931,7 +931,8 @@ void phylink_destroy(struct phylink *pl)
  }
  EXPORT_SYMBOL_GPL(phylink_destroy);
  


### PR DESCRIPTION
Removed upstreamed:
    bcm53xx/patches-5.10/033-v5.16-0024-ARM-dts-BCM5301X-Fix-I2C-controller-interrupt.patch[1]
    bcm53xx/patches-5.10/033-v5.16-0025-ARM-dts-BCM5301X-Add-interrupt-properties-to-GPIO-no.patch[2]

All other patches automatically rebased.

1. https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=v5.10.83&id=b2cd6fdcbe0a5cb44e4610a08cc58261d494a885
2. https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=v5.10.83&id=9db1d4a3c2700e1cc84c3d61199411d75c2a3ec6

Build system: x86_64*
Build-tested: bcm2711/RPi4B, ipq806x/R7800†
Run-tested: bcm2711/RPi4B, ipq806x/R7800†

* Had to revert 7c99085bd69742f66207d61e9f2da5ec4f8f9d2f in order to build
  (latest bump of ca-certificates)

† Had to revert 7f1edbd41295dff9f2127b169fbc086c0fb2c14e in order to build
  (binutils 2.37, https://bugs.openwrt.org/index.php?do=details&task_id=4149)

Signed-off-by: graysky <graysky@archlinux.us>

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [ ] 我知道
