### PR TITLE
kernel: Add missing devm_regulator_get_exclusive() (#9411)

### DIFF
--- a/target/linux/generic/backport-5.10/900-regulator-consumer-Add-missing-stubs-to-regulator-co.patch
+++ b/target/linux/generic/backport-5.10/900-regulator-consumer-Add-missing-stubs-to-regulator-co.patch
@@ -1,0 +1,79 @@
+From a71658c7db0b2be9fcab3522aeabe11792a4f481 Mon Sep 17 00:00:00 2001
+From: Dmitry Osipenko <digetx@gmail.com>
+Date: Wed, 20 Jan 2021 23:58:44 +0300
+Subject: [PATCH] regulator: consumer: Add missing stubs to
+ regulator/consumer.h
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+commit 51dfb6ca3728bd0a0a3c23776a12d2a15a1d2457 upstream.
+
+Add missing stubs to regulator/consumer.h in order to fix COMPILE_TEST
+of the kernel. In particular this should fix compile-testing of OPP core
+because of a missing stub for regulator_sync_voltage().
+
+Reported-by: kernel test robot <lkp@intel.com>
+Signed-off-by: Dmitry Osipenko <digetx@gmail.com>
+Link: https://lore.kernel.org/r/20210120205844.12658-1-digetx@gmail.com
+Signed-off-by: Mark Brown <broonie@kernel.org>
+Cc: Bjørn Mork <bjorn@mork.no>
+Cc: Sudip Mukherjee <sudipm.mukherjee@gmail.com>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ include/linux/regulator/consumer.h | 30 ++++++++++++++++++++++++++++++
+ 1 file changed, 30 insertions(+)
+
+--- a/include/linux/regulator/consumer.h
++++ b/include/linux/regulator/consumer.h
+@@ -332,6 +332,12 @@ regulator_get_exclusive(struct device *d
+ }
+ 
+ static inline struct regulator *__must_check
++devm_regulator_get_exclusive(struct device *dev, const char *id)
++{
++	return ERR_PTR(-ENODEV);
++}
++
++static inline struct regulator *__must_check
+ regulator_get_optional(struct device *dev, const char *id)
+ {
+ 	return ERR_PTR(-ENODEV);
+@@ -486,6 +492,11 @@ static inline int regulator_get_voltage(
+ 	return -EINVAL;
+ }
+ 
++static inline int regulator_sync_voltage(struct regulator *regulator)
++{
++	return -EINVAL;
++}
++
+ static inline int regulator_is_supported_voltage(struct regulator *regulator,
+ 				   int min_uV, int max_uV)
+ {
+@@ -578,6 +589,25 @@ static inline int devm_regulator_unregis
+ 	return 0;
+ }
+ 
++static inline int regulator_suspend_enable(struct regulator_dev *rdev,
++					   suspend_state_t state)
++{
++	return -EINVAL;
++}
++
++static inline int regulator_suspend_disable(struct regulator_dev *rdev,
++					    suspend_state_t state)
++{
++	return -EINVAL;
++}
++
++static inline int regulator_set_suspend_voltage(struct regulator *regulator,
++						int min_uV, int max_uV,
++						suspend_state_t state)
++{
++	return -EINVAL;
++}
++
+ static inline void *regulator_get_drvdata(struct regulator *regulator)
+ {
+ 	return NULL;


### PR DESCRIPTION
This backports a patch from Linux 5.10.116 to fix a compile problem
introduced in 5.10.114.

drivers/usb/phy/phy-generic.c could not find
devm_regulator_get_exclusive().

Fixes: #9410
Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [ ] 我知道
