### PR TITLE
ipq807x: add default packages about nss (#9920)

### DIFF
--- a/target/linux/ipq807x/Makefile
+++ b/target/linux/ipq807x/Makefile
@@ -18,6 +18,7 @@ DEFAULT_PACKAGES += \
 	autocore-arm htop wpad-openssl zram-swap uboot-envtools \
 	kmod-qca-nss-dp kmod-qca-nss-drv-64 \
 	kmod-qca-nss-drv-pppoe-64 kmod-qca-nss-ecm-64 \
+	kmod-qca-nss-drv-bridge-mgr-64 kmod-qca-nss-drv-vlan-mgr-64 \
 	nss-firmware-ipq8074 luci-app-ipsec-vpnd \
 	luci-app-unblockmusic luci-app-zerotier
 


### PR DESCRIPTION
Add qca-nss-drv-bridge-mgr-64 and kmod-qca-nss-drv-vlan-mgr-64.

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [ ] 我知道
